### PR TITLE
Moving set offset and limit to getQuery() from execute() Fix #8

### DIFF
--- a/src/PHPCR/Util/QOM/QueryBuilder.php
+++ b/src/PHPCR/Util/QOM/QueryBuilder.php
@@ -416,6 +416,15 @@ class QueryBuilder
         }
         $this->state = self::STATE_CLEAN;
         $this->query = $this->qomFactory->createQuery($this->source, $this->constraint, $this->orderings, $this->columns);
+
+        if ($this->firstResult) {
+            $this->query->setOffset($this->firstResult);
+        }
+
+        if ($this->maxResults) {
+            $this->query->setLimit($this->maxResults);
+        }
+
         return $this->query;
     }
 
@@ -428,14 +437,6 @@ class QueryBuilder
     {
         if ($this->query === null || $this->state === self::STATE_DIRTY) {
             $this->query = $this->getQuery();
-        }
-
-        if ($this->firstResult) {
-            $this->query->setOffset($this->firstResult);
-        }
-
-        if ($this->maxResults) {
-            $this->query->setLimit($this->maxResults);
         }
 
         foreach ($this->params as $key => $value) {

--- a/tests/PHPCR/Tests/Util/QOM/QueryBuilderTest.php
+++ b/tests/PHPCR/Tests/Util/QOM/QueryBuilderTest.php
@@ -196,7 +196,24 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase
                  ->method('createQuery')
                  ->will($this->returnValue("true"));
         $qb->getQuery();
-        //state is clean, query is stored
+    }
+    public function testGetQueryWithOffsetAndLimit()
+    {
+        $source = $this->getMock('PHPCR\Query\QOM\SourceInterface', array(), array());
+        $constraint = $this->getMock('PHPCR\Query\QOM\ConstraintInterface', array(), array());
+        $query = $this->getMock('PHPCR\Query\QOM\QueryObjectModelInterface', array(), array());
+        $qb = new QueryBuilder($this->qf);
+        $qb->from($source);
+        $qb->where($constraint);
+        $qb->setFirstResult(13);
+        $qb->setMaxResults(42);
+        $query->expects($this->once())
+              ->method('setOffset');
+        $query->expects($this->once())
+              ->method('setLimit');
+        $this->qf->expects($this->once())
+                 ->method('createQuery')
+                 ->will($this->returnValue($query));
         $qb->getQuery();
     }
 


### PR DESCRIPTION
Per @dbu 's comments, I see this more clearly after trying to implement findBy in the ODM.
