### PR TITLE
the default order should be ascending

### DIFF
--- a/src/PHPCR/Util/QOM/QueryBuilder.php
+++ b/src/PHPCR/Util/QOM/QueryBuilder.php
@@ -210,10 +210,10 @@ class QueryBuilder
     public function orderBy(DynamicOperandInterface $sort, $order = null)
     {
         $this->state = self::STATE_DIRTY;
-        if ($order == 'ASC' ) {
-            $ordering = $this->qomFactory->ascending($sort);
-        } else {
+        if ($order == 'DESC' ) {
             $ordering = $this->qomFactory->descending($sort);
+        } else {
+            $ordering = $this->qomFactory->ascending($sort);
         }
         $this->orderings = array($ordering);
         return $this;


### PR DESCRIPTION
The default ordering was descending if not specified in the "order by" instruction. It is now ascending, according to standard databases. 
