### PR TITLE
Fix an issue, if there's no selector in PropertyExistence

### DIFF
--- a/src/PHPCR/Util/QOM/Sql2Generator.php
+++ b/src/PHPCR/Util/QOM/Sql2Generator.php
@@ -294,7 +294,8 @@ class Sql2Generator
 
     public function evalPropertyExistence($selectorName, $propertyName)
     {
-        return "$selectorName.$propertyName IS NOT NULL";
+        $sql2 = is_null($selectorName) ? $propertyName : $selectorName . '.' . $propertyName;
+        return $sql2 . " IS NOT NULL";
     }
 
     /**


### PR DESCRIPTION
If no selectorName was given, it didn't work.
