### PR TITLE
Dot not escaped in path eval in Sql2Generator.php

### DIFF
--- a/src/PHPCR/Util/QOM/Sql2Generator.php
+++ b/src/PHPCR/Util/QOM/Sql2Generator.php
@@ -325,7 +325,7 @@ class Sql2Generator extends BaseSqlGenerator
             $sql2 = $path;
             // only ensure proper quoting if the user did not quote himself, we trust him to get it right if he did.
             if (substr($path, 0,1) !== '[' && substr($path, -1) !== ']') {
-                if (false !== strpos($sql2, ' ')) {
+                if (false !== strpos($sql2, ' ') || false !== strpos($sql2, '.')) {
                     $sql2 = '"' . $sql2 . '"';
                 }
                 $sql2 = '[' . $sql2 . ']';


### PR DESCRIPTION
I found this broken for my node path which was something like
/mypath/pages/23948327.3489

Im sure this fixes my problem. But I think its probably better to check for non-alpha-numeric characters using a regex.  But I leave that for the SQL2 gurus since this is my first real encounter with SQL2
