### PR TITLE
Improved orderBy logic in query builder

### DIFF
--- a/src/PHPCR/Util/QOM/QueryBuilder.php
+++ b/src/PHPCR/Util/QOM/QueryBuilder.php
@@ -193,6 +193,12 @@ class QueryBuilder
      */
     public function addOrderBy(DynamicOperandInterface $sort, $order = 'ASC')
     {
+        $order = strtoupper($order);
+
+        if (!in_array($order, array('ASC', 'DESC'))) {
+            throw new \InvalidArgumentException('Order must be one of "ASC" or "DESC"');
+        }
+
         $this->state = self::STATE_DIRTY;
         if ($order == 'DESC') {
             $ordering = $this->qomFactory->descending($sort);
@@ -213,15 +219,10 @@ class QueryBuilder
      *
      * @return QueryBuilder This QueryBuilder instance.
      */
-    public function orderBy(DynamicOperandInterface $sort, $order = null)
+    public function orderBy(DynamicOperandInterface $sort, $order = 'ASC')
     {
-        $this->state = self::STATE_DIRTY;
-        if ($order == 'DESC') {
-            $ordering = $this->qomFactory->descending($sort);
-        } else {
-            $ordering = $this->qomFactory->ascending($sort);
-        }
-        $this->orderings = array($ordering);
+        $this->orderings = array();
+        $this->addOrderBy($sort, $order);
 
         return $this;
     }

--- a/tests/PHPCR/Tests/Util/QOM/QueryBuilderTest.php
+++ b/tests/PHPCR/Tests/Util/QOM/QueryBuilderTest.php
@@ -37,6 +37,26 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase
         $orderings = $qb->getOrderings();
     }
 
+    public function testAddOrderByLowercase()
+    {
+        $dynamicOperand = $this->getMock('PHPCR\Query\QOM\DynamicOperandInterface', array(), array());
+        $qb = new QueryBuilder($this->qf);
+        $qb->addOrderBy($dynamicOperand, 'asc');
+        $qb->addOrderBy($dynamicOperand, 'desc');
+        $this->assertEquals(2, count($qb->getOrderings()));
+        $orderings = $qb->getOrderings();
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testAddOrderByInvalid()
+    {
+        $dynamicOperand = $this->getMock('PHPCR\Query\QOM\DynamicOperandInterface', array(), array());
+        $qb = new QueryBuilder($this->qf);
+        $qb->addOrderBy($dynamicOperand, 'FOO');
+    }
+
     public function testOrderBy()
     {
         $dynamicOperand = $this->getMock('PHPCR\Query\QOM\DynamicOperandInterface', array(), array());


### PR DESCRIPTION
- Order order always sanitized to uppercase  -- should it be?
- Validation to check that given value is one of "ASC" or "DESC"
- orderBy reuses existing addOrderBy rather than copying the logic
