### PR TITLE
Qomf shortcut

### DIFF
--- a/src/PHPCR/Util/QOM/QueryBuilder.php
+++ b/src/PHPCR/Util/QOM/QueryBuilder.php
@@ -123,6 +123,14 @@ class QueryBuilder
     }
 
     /**
+     * Shortcut for getQOMFactory()
+     */
+    public function qomf()
+    {
+        return $this->getQOMFactory();
+    }
+
+    /**
      * sets the position of the first result to retrieve (the "offset").
      *
      * @param integer $firstResult The First result to return.


### PR DESCRIPTION
I have added a shortcut for `->getQOMFactory()`, `->qomf()` which is more analogous to the ORM's `->expr()` shortcut.

``` php
    $qb->orWhere($qb->qomf()->comparison(
        $qb->qomf()->propertyValue('blog'),
        QOMConstants::JCR_OPERATOR_EQUAL_TO,
        $qb->qomf()->literal('My Blog')
    ));
```

rather than:

``` php
            $qomf = $qb->getQOMFactory();
            $qb->orWhere($qomf->comparison(
                $qomf->propertyValue('blog'),
                Constants::JCR_OPERATOR_EQUAL_TO,
                $qomf->literal($options['blog_uuid'])
            ));
```

What do you think?

Do you think it would be correct to add a shortcut for the Constants aswell?

``` php
  $qb->qomf()->operator('equal_to'); // or
  $qb->constrants('operator_equal_to'); // or
  $qb->operator('equal_to');
```
