### PR TITLE
Fixed edge case for getPathForDescendantQuery

### DIFF
--- a/src/PHPCR/Util/Console/Command/QueryCommand.php
+++ b/src/PHPCR/Util/Console/Command/QueryCommand.php
@@ -58,7 +58,12 @@ class QueryCommand extends Command
             $query->setOffset($offset);
         }
 
+        $output->writeln(sprintf('<info>Executing, language:</info> %s', $query->getLanguage()));
+
+        $start = microtime(true);
         $result = $query->execute();
+        $elapsed = microtime(true) - $start; 
+
         $output->writeln("Results:\n");
         foreach ($result as $i => $row) {
             $output->writeln("\n".($i+1).'. Row (Path: '. $row->getPath() .', Score: '. $row->getScore() .'):');
@@ -66,6 +71,7 @@ class QueryCommand extends Command
                 $output->writeln("$column: $value");
             }
         }
+        $output->writeln(sprintf('<info>%.2f seconds</info>', $elapsed));
 
         return 0;
     }

--- a/src/PHPCR/Util/QOM/QueryBuilder.php
+++ b/src/PHPCR/Util/QOM/QueryBuilder.php
@@ -412,7 +412,7 @@ class QueryBuilder
      *
      * @return QueryBuilder This QueryBuilder instance.
      *
-     * @trows RuntimeException if there is not an existing source.
+     * @throws RuntimeException if there is not an existing source.
      */
     public function join(SourceInterface $rightSource, JoinConditionInterface $joinCondition)
     {
@@ -427,7 +427,7 @@ class QueryBuilder
      *
      * @return QueryBuilder This QueryBuilder instance.
      *
-     * @trows RuntimeException if there is not an existing source.
+     * @throws RuntimeException if there is not an existing source.
      */
     public function innerJoin(SourceInterface $rightSource, JoinConditionInterface $joinCondition)
     {
@@ -442,7 +442,7 @@ class QueryBuilder
      *
      * @return QueryBuilder This QueryBuilder instance.
      *
-     * @trows RuntimeException if there is not an existing source.
+     * @throws RuntimeException if there is not an existing source.
      */
     public function leftJoin(SourceInterface $rightSource, JoinConditionInterface $joinCondition)
     {
@@ -457,7 +457,7 @@ class QueryBuilder
      *
      * @return QueryBuilder This QueryBuilder instance.
      *
-     * @trows RuntimeException if there is not an existing source.
+     * @throws RuntimeException if there is not an existing source.
      */
     public function rightJoin(SourceInterface $rightSource, JoinConditionInterface $joinCondition)
     {
@@ -473,7 +473,7 @@ class QueryBuilder
      *
      * @return QueryBuilder This QueryBuilder instance.
      *
-     * @trows RuntimeException if there is not an existing source.
+     * @throws RuntimeException if there is not an existing source.
      */
     public function joinWithType(SourceInterface $rightSource, $joinType, JoinConditionInterface $joinCondition)
     {

--- a/src/PHPCR/Util/QOM/Sql1Generator.php
+++ b/src/PHPCR/Util/QOM/Sql1Generator.php
@@ -26,9 +26,13 @@ class Sql1Generator extends BaseSqlGenerator
 
     protected function getPathForDescendantQuery($path)
     {
-        $path = trim($path,"\"'/");
-        $sql1 = "/" . str_replace("/","[%]/",$path) ;
-        $sql1 .= "[%]/%";
+        if ($path == '/') {
+            $sql1 = '/%';
+        } else {
+            $path = trim($path,"\"'/");
+            $sql1 = "/" . str_replace("/","[%]/",$path) ;
+            $sql1 .= "[%]/%";
+        }
 
         return $sql1;
     }

--- a/tests/PHPCR/Tests/Util/QOM/Sql1GeneratorTest.php
+++ b/tests/PHPCR/Tests/Util/QOM/Sql1GeneratorTest.php
@@ -45,12 +45,18 @@ class Sql1GeneratorTest extends \PHPUnit_Framework_TestCase
 
     public function testChildNode()
     {
+        $literal = $this->generator->evalChildNode("/");
+        $this->assertSame("jcr:path LIKE '/%' AND NOT jcr:path LIKE '/%/%'", $literal);
+
         $literal = $this->generator->evalChildNode("/foo/bar/baz");
         $this->assertSame("jcr:path LIKE '/foo[%]/bar[%]/baz[%]/%' AND NOT jcr:path LIKE '/foo[%]/bar[%]/baz[%]/%/%'", $literal);
     }
 
     public function testDescendantNode()
     {
+        $literal = $this->generator->evalDescendantNode("/");
+        $this->assertSame("jcr:path LIKE '/%'", $literal);
+
         $literal = $this->generator->evalDescendantNode("/foo/bar/baz");
         $this->assertSame("jcr:path LIKE '/foo[%]/bar[%]/baz[%]/%'", $literal);
     }


### PR DESCRIPTION
- e.g. $qomf->descendantNode("/") now works
- Some other random fixes
  - Fixed typo in DocBlocks
  - Command doctrine:phpcr:query
    - Display language when executing query via  (I
      was wondering why my query wasn't working, it was being executed as
      JCR_SQL2 and not SQL)
    - Display query execution time
