### PR TITLE
[RFC] Reorganizing command names

### DIFF
--- a/bin/phpcr
+++ b/bin/phpcr
@@ -40,15 +40,17 @@ $cli = new \Symfony\Component\Console\Application('PHPCR Command Line Interface'
 $cli->setCatchExceptions(true);
 $cli->setHelperSet($helperSet);
 $cli->addCommands(array(
-    new \PHPCR\Util\Console\Command\CreateWorkspaceCommand(),
-    new \PHPCR\Util\Console\Command\ImportXmlCommand(),
-    new \PHPCR\Util\Console\Command\DumpCommand(),
-    new \PHPCR\Util\Console\Command\PurgeCommand(),
-    new \PHPCR\Util\Console\Command\RegisterNodeTypesCommand(),
-    new \PHPCR\Util\Console\Command\ListNodeTypesCommand(),
-    new \PHPCR\Util\Console\Command\QueryCommand(),
-    new \PHPCR\Util\Console\Command\MoveCommand(),
-    new \PHPCR\Util\Console\Command\TouchCommand(),
+    new \PHPCR\Util\Console\Command\NodeDumpCommand(),
+    new \PHPCR\Util\Console\Command\NodeMoveCommand(),
+    new \PHPCR\Util\Console\Command\NodeRemoveCommand(),
+    new \PHPCR\Util\Console\Command\NodeTouchCommand(),
+    new \PHPCR\Util\Console\Command\NodeTypeListCommand(),
+    new \PHPCR\Util\Console\Command\NodeTypeRegisterCommand(),
+    new \PHPCR\Util\Console\Command\WorkspaceCreateCommand(),
+    new \PHPCR\Util\Console\Command\WorkspaceExportCommand(),
+    new \PHPCR\Util\Console\Command\WorkspaceImportCommand(),
+    new \PHPCR\Util\Console\Command\WorkspacePurgeCommand(),
+    new \PHPCR\Util\Console\Command\WorkspaceQueryCommand(),
 ));
 $cli->run();
 

--- a/src/PHPCR/Util/Console/Command/NodeDumpCommand.php
+++ b/src/PHPCR/Util/Console/Command/NodeDumpCommand.php
@@ -41,7 +41,7 @@ use PHPCR\Util\Console\Helper\TreeDumper\SystemNodeFilter;
  *
  * @author Daniel Barsotti <daniel.barsotti@liip.ch>
  */
-class DumpCommand extends Command
+class NodeDumpCommand extends Command
 {
     /**
      * Limit after which to cut lines when dumping properties
@@ -56,7 +56,7 @@ class DumpCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('phpcr:dump')
+            ->setName('phpcr:node:dump')
             ->addOption('sys_nodes', null, InputOption::VALUE_NONE, 'Use to dump the system nodes')
             ->addOption('props', null, InputOption::VALUE_NONE, 'Use to dump the node properties')
             ->addOption('depth', null, InputOption::VALUE_OPTIONAL, 'Set to a number to limit how deep into the tree to recurse', "-1")

--- a/src/PHPCR/Util/Console/Command/NodeMoveCommand.php
+++ b/src/PHPCR/Util/Console/Command/NodeMoveCommand.php
@@ -31,7 +31,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @author Daniel Leech <daniel@dantleech.com>
  */
-class MoveCommand extends Command
+class NodeMoveCommand extends Command
 {
     /**
      * {@inheritDoc}
@@ -39,7 +39,7 @@ class MoveCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('phpcr:move')
+            ->setName('phpcr:node:move')
             ->addArgument('source', InputArgument::REQUIRED, 'Path of node to move')
             ->addArgument('destination', InputArgument::REQUIRED, 'Destination for node')
             ->setDescription('Moves a node from one path to another')

--- a/src/PHPCR/Util/Console/Command/NodeRemoveCommand.php
+++ b/src/PHPCR/Util/Console/Command/NodeRemoveCommand.php
@@ -36,7 +36,7 @@ use PHPCR\Util\NodeHelper;
  *
  * @author Daniel Barsotti <daniel.barsotti@liip.ch>
  */
-class PurgeCommand extends Command
+class NodeRemoveCommand extends Command
 {
     /**
      * {@inheritDoc}
@@ -46,13 +46,22 @@ class PurgeCommand extends Command
         parent::configure();
 
         $this
-            ->setName('phpcr:purge')
+            ->setName('phpcr:node:remove')
             ->setDescription('Remove content from the repository')
             ->addArgument('path', InputArgument::OPTIONAL, 'Path of the node to purge', '/')
             ->addOption('force', null, InputOption::VALUE_NONE, 'Use to bypass the confirmation dialog')
             ->addOption('only-children', null, InputOption::VALUE_NONE, 'Use to only purge children of specified path')
             ->setHelp(<<<EOF
-The <info>phpcr:purge</info> command remove all the non-standard nodes from the content repository
+The <info>phpcr:node:remove</info> command will remove the given node or the 
+children of the given node according to the options given.
+
+Remove specified node and its children:
+
+    $ php bin/phpcr phpcr:node:remove /cms/content/blog
+
+Remove only the children of the specified node
+
+    $ php bin/phpcr phpcr:node:remove /cms/content/blog --only-children
 EOF
             )
         ;
@@ -89,7 +98,7 @@ EOF
         }
 
         if ($force) {
-            $message = '<comment>></comment> <info>Purging: </info> %s';
+            $message = '<comment>></comment> <info>Purging: </info>%s';
 
             if ($onlyChildren) {
                 $baseNode = $session->getNode($path, 0);
@@ -102,7 +111,10 @@ EOF
                 $output->writeln(sprintf($message, $path));
 
                 if ('/' === $path) {
-                    NodeHelper::purgeWorkspace($this->getHelper('phpcr')->getSession());
+                    throw new \Exception(
+                        'Will not purge path entire workspace ("/"), use the '.
+                        'workspace:purge method instead.'
+                    );
                 } else {
                     $session->removeItem($path);
                 }

--- a/src/PHPCR/Util/Console/Command/NodeTouchCommand.php
+++ b/src/PHPCR/Util/Console/Command/NodeTouchCommand.php
@@ -34,7 +34,7 @@ use PHPCR\PathNotFoundException;
  *
  * @author Daniel Leech <daniel@dantleech.com>
  */
-class TouchCommand extends Command
+class NodeTouchCommand extends Command
 {
     /**
      * {@inheritDoc}
@@ -43,7 +43,7 @@ class TouchCommand extends Command
     {
         parent::configure();
 
-        $this->setName('phpcr:touch')
+        $this->setName('phpcr:node:touch')
             ->addArgument(
                 'path', 
                 InputArgument::REQUIRED, 

--- a/src/PHPCR/Util/Console/Command/NodeTypeListCommand.php
+++ b/src/PHPCR/Util/Console/Command/NodeTypeListCommand.php
@@ -30,7 +30,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @author Daniel Leech <daniel@dantleech.com>
  */
-class ListNodeTypesCommand extends Command
+class NodeTypeListCommand extends Command
 {
     /**
      * {@inheritDoc}
@@ -38,7 +38,7 @@ class ListNodeTypesCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('phpcr:type:list')
+            ->setName('phpcr:node-type:list')
             ->setDescription('List all available node types in the repository')
             ->setHelp(<<<EOT
 This command lists all of the available node types and their subtypes

--- a/src/PHPCR/Util/Console/Command/NodeTypeRegisterCommand.php
+++ b/src/PHPCR/Util/Console/Command/NodeTypeRegisterCommand.php
@@ -39,7 +39,7 @@ use PHPCR\NodeType\NodeTypeExistsException;
  *
  * @author Uwe Jäger <uwej711@googlemail.com>
  */
-class RegisterNodeTypesCommand extends Command
+class NodeTypeRegisterCommand extends Command
 {
     /**
      * {@inheritDoc}
@@ -47,7 +47,7 @@ class RegisterNodeTypesCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('phpcr:type:register')
+            ->setName('phpcr:node-type:register')
             ->setDescription('Register node types in the PHPCR repository')
             ->setDefinition(array(
                 new InputArgument(

--- a/src/PHPCR/Util/Console/Command/WorkspaceCreateCommand.php
+++ b/src/PHPCR/Util/Console/Command/WorkspaceCreateCommand.php
@@ -32,7 +32,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>
  * @author David Buchmann <david@liip.ch>
  */
-class CreateWorkspaceCommand extends Command
+class WorkspaceCreateCommand extends Command
 {
     /**
      * {@inheritDoc}

--- a/src/PHPCR/Util/Console/Command/WorkspaceExportCommand.php
+++ b/src/PHPCR/Util/Console/Command/WorkspaceExportCommand.php
@@ -34,7 +34,7 @@ use PHPCR\RepositoryInterface;
  *
  * @author David Buchmann <david@liip.ch>
  */
-class ExportXmlCommand extends Command
+class WorkspaceExportCommand extends Command
 {
     /**
      * {@inheritDoc}
@@ -44,7 +44,7 @@ class ExportXmlCommand extends Command
         parent::configure();
 
         $this
-            ->setName('phpcr:export')
+            ->setName('phpcr:workspace:export')
             ->addArgument('filename', InputArgument::REQUIRED, 'The xml file to export to')
             ->addOption('path', 'p', InputOption::VALUE_OPTIONAL, 'Path of the node to export', '/')
             ->addOption('skip_binary', null, InputOption::VALUE_OPTIONAL, 'Set to "yes" to skip binaries', "no")

--- a/src/PHPCR/Util/Console/Command/WorkspaceImportCommand.php
+++ b/src/PHPCR/Util/Console/Command/WorkspaceImportCommand.php
@@ -34,7 +34,7 @@ use PHPCR\ImportUUIDBehaviorInterface;
  *
  * @author David Buchmann <david@liip.ch>
  */
-class ImportXmlCommand extends Command
+class WorkspaceImportCommand extends Command
 {
     /**
      * {@inheritDoc}
@@ -44,7 +44,7 @@ class ImportXmlCommand extends Command
         parent::configure();
 
         $this
-            ->setName('phpcr:import')
+            ->setName('phpcr:workspace:import')
             ->addArgument('filename', null, 'The xml file to import')
             ->addOption('parentpath', 'p', InputOption::VALUE_OPTIONAL, 'Repository path to the parent where to import the file contents', '/')
             ->setDescription('Import xml data into the repository, either in JCR system view format or arbitrary xml')

--- a/src/PHPCR/Util/Console/Command/WorkspaceListCommand.php
+++ b/src/PHPCR/Util/Console/Command/WorkspaceListCommand.php
@@ -30,7 +30,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>
  */
-class ListWorkspacesCommand extends Command
+class WorkspaceListCommand extends Command
 {
     /**
      * {@inheritDoc}

--- a/src/PHPCR/Util/Console/Command/WorkspacePurgeCommand.php
+++ b/src/PHPCR/Util/Console/Command/WorkspacePurgeCommand.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This file is part of the PHPCR Utils
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @license http://www.apache.org/licenses/LICENSE-2.0 Apache Software License 2.0
+ * @link http://phpcr.github.com/
+ */
+
+namespace PHPCR\Util\Console\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\DialogHelper;
+
+use PHPCR\Util\NodeHelper;
+
+/**
+ * Command to remove all nodes from a path in the workspace of the configured
+ * session.
+ *
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+class WorkspacePurgeCommand extends Command
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('phpcr:workspace:purge')
+            ->setDescription('Remove all nodes from a workspace')
+            ->addOption('force', null, InputOption::VALUE_NONE, 'Use to bypass the confirmation dialog')
+            ->setHelp(<<<EOF
+The <info>phpcr:purge</info> command remove all the non-standard nodes from the workspace.
+EOF
+            )
+        ;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $session = $this->getHelper('phpcr')->getSession();
+        $force = $input->getOption('force');
+
+        if (!$force) {
+            $dialog = new DialogHelper();
+            $workspaceName = $session->getWorkspace()->getName();
+            $force = $dialog->askConfirmation($output, sprintf(
+                '<question>Are you sure you want to purge workspace "%s" Y/N ?</question>', 
+                $workspaceName
+            ), false);
+        }
+
+        if ($force) {
+            $message = '';
+            $output->writeln(sprintf('<info>Purging workspace:</info> %s', $path));
+            NodeHelper::purgeWorkspace($session);
+            $session->save();
+        } else {
+            $output->writeln('<error>Aborted</error>');
+        }
+
+        return 0;
+    }
+}
+

--- a/src/PHPCR/Util/Console/Command/WorkspaceQueryCommand.php
+++ b/src/PHPCR/Util/Console/Command/WorkspaceQueryCommand.php
@@ -33,7 +33,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @author Daniel Barsotti <daniel.barsotti@liip.ch>
  */
-class QueryCommand extends Command
+class WorkspaceQueryCommand extends Command
 {
     /**
      * {@inheritDoc}
@@ -42,7 +42,7 @@ class QueryCommand extends Command
     {
         parent::configure();
 
-        $this->setName('phpcr:query')
+        $this->setName('phpcr:workspace:query')
             ->addArgument('query', InputArgument::REQUIRED, 'A query statement to execute')
             ->addOption('language', 'l', InputOption::VALUE_OPTIONAL, 'The query language (sql, jcr_sql2', 'jcr_sql2')
             ->addOption('limit', null, InputOption::VALUE_OPTIONAL, 'The query limit', 0)


### PR DESCRIPTION
This is just an proof of concept PR, so basically I propose to renmae the classes as follows:

```
./NodeMoveCommand.php
./NodeRemoveCommand.php
./NodeTouchCommand.php
./NodeTypeListCommand.php
./NodeTypeRegisterCommand.php
./WorkspaceCreateCommand.php
./WorkspaceDumpCommand.php
./WorkspaceExportCommand.php
./WorkspaceImportCommand.php
./WorkspaceListCommand.php
./WorkspacePurgeCommand.php
./WorkspaceQueryCommand.php
```

and that would then translate to the following command schema:

```
phpcr:workspace:purge
phpcr:workspace:import
phpcr:workspace:query
...
phpcr:node-type:register
...
phpcr:node:touch
...
```

Not sure if I have categorized things correctly, does `dump`,`import|export` etc belong in `workspace`?
