### PR TITLE
NodeTouchCommand failing on windows

### DIFF
--- a/src/PHPCR/Util/Console/Command/NodeTouchCommand.php
+++ b/src/PHPCR/Util/Console/Command/NodeTouchCommand.php
@@ -29,6 +29,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use PHPCR\PathNotFoundException;
+use PHPCR\Util\PathHelper;
 
 /**
  * Command to create a PHPCR node of a specified type from
@@ -122,8 +123,8 @@ HERE
             }
         } else {
 
-            $nodeName = basename($path);
-            $parentPath = dirname($path);
+            $nodeName = PathHelper::getNodeName($path);
+            $parentPath = PathHelper::getParentPath($path);
 
             try {
                 $parentNode = $session->getNode($parentPath);


### PR DESCRIPTION
The NodeTouchCommand uses `dirname` and `basename` for operations on PHPCR-paths. This causes problems because Windows might return `\` instead of `/` as the root-path.

It breaks the unit test completely:

```
C:\[...]\jackalope-doctrine-dbal> phpunit
...  
Fatal error: Call to a member function addNode() on a non-object in C:\[...]\NodeTouchCommand.php on line 143
```

And just throws an exception if you want to "touch" a node:

```
C:\[...]\jackalope-doctrine-dbal> php bin\jackalope phpcr:node:touch /gopf --type nt:unstructured

  [PHPCR\RepositoryException]
  Not an absolute path '\'
```

This pull request solves the problem by simply replacing the "php-based" filesystem-functions with the `PathHelper`-counterparts.
