### PR TITLE
Instantiate helper in-class - bug fix

### DIFF
--- a/src/PHPCR/Util/Console/Command/BaseCommand.php
+++ b/src/PHPCR/Util/Console/Command/BaseCommand.php
@@ -8,10 +8,12 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use PHPCR\Util\Console\Helper\PhpcrCliHelper;
+use PHPCR\Util\Console\Helper\PhpcrConsoleDumperHelper;
 
 abstract class BaseCommand extends Command
 {
     protected $phpcrCliHelper;
+    protected $phpcrConsoleDumperHelper;
 
     /**
      * @return SessionInterface
@@ -31,6 +33,23 @@ abstract class BaseCommand extends Command
         }
 
         return $this->phpcrCliHelper;
+    }
+
+    /** 
+     * @return PhpcrConsoleDumperHelper 
+     */
+    protected function getPhpcrConsoleDumperHelper()
+    {
+        if (!$this->phpcrConsoleDumperHelper) {
+            $this->phpcrConsoleDumperHelper = new PhpcrConsoleDumperHelper();
+        }
+
+        return $this->phpcrConsoleDumperHelper;
+    }
+
+    public function setPhpcrConsoleDumperHelper($consoleDumperHelper)
+    {
+        $this->phpcrConsoleDumperHelper = $consoleDumperHelper;
     }
 
     /**

--- a/src/PHPCR/Util/Console/Command/NodeDumpCommand.php
+++ b/src/PHPCR/Util/Console/Command/NodeDumpCommand.php
@@ -76,8 +76,7 @@ HERE
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $session = $this->getPhpcrSession();
-        /** @var $dumperHelper PhpcrConsoleDumperHelper */
-        $dumperHelper = $this->getHelper('phpcr_console_dumper');
+        $dumperHelper = $this->getPhpcrConsoleDumperHelper();
 
         // node to dump
         $identifier = $input->getArgument('identifier');

--- a/tests/PHPCR/Tests/Util/Console/Command/BaseCommandTest.php
+++ b/tests/PHPCR/Tests/Util/Console/Command/BaseCommandTest.php
@@ -82,7 +82,6 @@ abstract class BaseCommandTest extends \PHPUnit_Framework_TestCase
 
         $this->helperSet = new HelperSet(array(
             'session' => new PhpcrHelper($this->session),
-            'phpcr_console_dumper' => $this->dumperHelper,
         ));
 
         $this->phpcrCliHelper = $this->getMockBuilder('PHPCR\Util\Console\Helper\PhpcrCliHelper')

--- a/tests/PHPCR/Tests/Util/Console/Command/NodeDumpCommandTest.php
+++ b/tests/PHPCR/Tests/Util/Console/Command/NodeDumpCommandTest.php
@@ -22,6 +22,13 @@ class NodeDumpCommandTest extends BaseCommandTest
         )->disableOriginalConstructor()->getMock();
     }
 
+    protected function addCommand()
+    {
+        $ndCommand = new NodeDumpCommand();
+        $ndCommand->setPhpcrConsoleDumperHelper($this->dumperHelper);
+        $this->application->add($ndCommand);
+    }
+
     public function testCommand()
     {
         $this->dumperHelper
@@ -41,8 +48,7 @@ class NodeDumpCommandTest extends BaseCommandTest
             ->with($this->node1)
         ;
 
-        $this->application->add(new NodeDumpCommand());
-
+        $this->addCommand();
         $this->executeCommand('phpcr:node:dump', array());
     }
 
@@ -67,14 +73,13 @@ class NodeDumpCommandTest extends BaseCommandTest
             ->with($this->node1)
         ;
 
-        $this->application->add(new NodeDumpCommand());
-
+        $this->addCommand();
         $this->executeCommand('phpcr:node:dump', array('identifier' => $uuid));
     }
 
     public function testInvalidRefFormat()
     {
-        $this->application->add(new NodeDumpCommand());
+        $this->addCommand();
 
         try {
             $this->executeCommand('phpcr:node:dump', array('--ref-format' => 'xy'));
@@ -93,7 +98,8 @@ class NodeDumpCommandTest extends BaseCommandTest
             ->will($this->throwException(new ItemNotFoundException()))
         ;
 
-        $this->application->add(new NodeDumpCommand());
+
+        $this->addCommand();
 
         $ct = $this->executeCommand('phpcr:node:dump', array(), 1);
         $this->assertContains('does not exist', $ct->getDisplay());


### PR DESCRIPTION
- Do not rely on helper being defined "outside" of the phpcr context.

Currently this is broken because the DoctrinePhpcrBundle does not create the helpers and there is all that wierd stuff going on in DoctrineCommandHelper.

The logic here is now the same as for PhpcrConsoleHelper
