### PR TITLE
Enable an actual closure to be passed to CliHelper apply-closures

### DIFF
--- a/src/PHPCR/Util/Console/Helper/PhpcrCliHelper.php
+++ b/src/PHPCR/Util/Console/Helper/PhpcrCliHelper.php
@@ -116,12 +116,20 @@ class PhpcrCliHelper extends Helper
             $node->removeMixin($removeMixin);
         }
 
-        foreach ($options['applyClosures'] as $closureString) {
-            $closure = create_function('$session, $node', $closureString);
-            $output->writeln(sprintf(
-                '<comment> > Applying closure: %s</comment>',
-                strlen($closureString) > 75 ? substr($closureString, 0, 72).'...' : $closureString
-            ));
+        foreach ($options['applyClosures'] as $closure) {
+            if ($closure instanceof \Closure) {
+                $output->writeln(
+                    '<comment> > Applying closure</comment>'
+                );
+            } else {
+                $closureString = $closure;
+                $closure = create_function('$session, $node', $closure);
+                $output->writeln(sprintf(
+                    '<comment> > Applying closure: %s</comment>',
+                    strlen($closureString) > 75 ? substr($closureString, 0, 72).'...' : $closureString
+                ));
+            }
+
             $closure($this->session, $node);
         }
 

--- a/tests/PHPCR/Tests/Util/Console/Command/NodesUpdateCommandTest.php
+++ b/tests/PHPCR/Tests/Util/Console/Command/NodesUpdateCommandTest.php
@@ -143,13 +143,16 @@ class NodesUpdateCommandTest extends BaseCommandTest
             '--query' => "SELECT foo FROM bar",
             '--no-interaction' => true,
             '--apply-closure' => array(
-                '$session->getNodeByIdentifier("/foo"); $node->setProperty("foo", "bar");'
+                '$session->getNodeByIdentifier("/foo"); $node->setProperty("foo", "bar");',
+                function ($session, $node) {
+                    $node->setProperty('foo', 'bar');
+                }
             ),
         );
 
         $this->setupQueryManager(array('query' => 'SELECT foo FROM bar'));
 
-        $this->node1->expects($this->once())
+        $this->node1->expects($this->exactly(2))
             ->method('setProperty')
             ->with('foo', 'bar');
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

This feature enables commands extending nodes:update to pass real closures rather than strings.
