### PR TITLE
Allow node names to be passed to getNodeName

### DIFF
--- a/src/PHPCR/Util/PathHelper.php
+++ b/src/PHPCR/Util/PathHelper.php
@@ -229,7 +229,15 @@ class PathHelper
      */
     public static function getNodeName($path)
     {
-        return substr($path, strrpos($path, '/') + 1);
+        $strrpos = strrpos($path, '/');
+
+        if (false === $strrpos) {
+            self::error(sprintf(
+                'Path "%s" must be an absolute path', $path
+            ), true);
+        }
+
+        return substr($path, $strrpos + 1);
     }
 
     /**

--- a/tests/PHPCR/Tests/Util/PathHelperTest.php
+++ b/tests/PHPCR/Tests/Util/PathHelperTest.php
@@ -249,21 +249,30 @@ class PathHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/', PathHelper::getParentPath('/'));
     }
 
-    // getNodeName tests
-
-    public function testGetNodeName()
+    public function provideGetNodeName()
     {
-        $this->assertEquals('child', PathHelper::getNodeName('/parent/child'));
+        return array(
+            array('/parent/child', 'child'),
+            array('/parent/ns:child', 'ns:child'),
+            array('/', ''),
+        );
     }
 
-    public function testGetNodeNameNamespaced()
+    /**
+     * @dataProvider provideGetNodeName
+     */
+    public function testGetNodeName($path, $expected = null)
     {
-        $this->assertEquals('ns:child', PathHelper::getNodeName('/parent/ns:child'));
+        $this->assertEquals($expected, PathHelper::getNodeName($path));
     }
 
-    public function testGetNodeNameRoot()
+    /**
+     * @expectedException PHPCR\RepositoryException
+     * @expectedExceptionMessage must be an absolute path
+     */
+    public function testGetNodeNameMustBeAbsolute()
     {
-        $this->assertEquals('', PathHelper::getNodeName('/'));
+        PathHelper::getNodeName('foobar');
     }
 
     public function testGetPathDepth()


### PR DESCRIPTION
This was required in my shell where the path arguments are sometimes relative node names,
