### PR TITLE
Fix node remove command from throwing an PHPCR\InvalidItemStateException

### DIFF
--- a/src/PHPCR/Util/Console/Command/NodeRemoveCommand.php
+++ b/src/PHPCR/Util/Console/Command/NodeRemoveCommand.php
@@ -105,8 +105,9 @@ EOF
 
             /** @var $childNode NodeInterface */
             foreach ($baseNode->getNodes() as $childNode) {
+                $childNodePath = $childNode->getPath();
                 $childNode->remove();
-                $output->writeln(sprintf($message, $childNode->getPath()));
+                $output->writeln(sprintf($message, $childNodePath));
             }
         } else {
             $session->removeItem($path);


### PR DESCRIPTION
Running `app/console doctrine:phpcr:node:remove --only-children /path` I noticed it currently throws an `PHPCR\InvalidItemStateException` stating `Item /path/node is deleted`. This small fix prevents accessing the deleted node.
