### PR TITLE
enable hhvm tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 5.3
   - 5.4
+  - hhvm
 
 before_script:
   - composer install --prefer-source --dev


### PR DESCRIPTION
there are only two test failures around value conversions:
- trying to convert 'test string' into a date does not throw an exception
- trying to convert a stream containing 'test string' into a date also does not throw an exception
