### PR TITLE
Fix HHVM tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,11 @@ php:
   - hhvm
 
 before_script:
+  - if [ $(phpenv version-name) = "hhvm" ]; then sudo mv /etc/hhvm /etc/hhvm.orig; fi
   - if [ $(phpenv version-name) = "hhvm" ]; then sudo apt-get update; fi
   - if [ $(phpenv version-name) = "hhvm" ]; then sudo apt-get install hhvm -qq -y --force-yes; fi
+  - if [ $(phpenv version-name) = "hhvm" ]; then sudo mv /etc/hhvm /etc/hhvm.new; fi
+  - if [ $(phpenv version-name) = "hhvm" ]; then sudo mv /etc/hhvm.orig /etc/hhvm; fi
   - composer self-update
   - composer install --prefer-source
 


### PR DESCRIPTION
Looks a bit hacky for now as `-y --force-yes` do not seem to work but it'll do the trick while 2.4 is not available by default
