### PR TITLE
[WIP] fix parsing dots in literals

### DIFF
--- a/src/PHPCR/Util/QOM/Sql2Scanner.php
+++ b/src/PHPCR/Util/QOM/Sql2Scanner.php
@@ -75,8 +75,7 @@ class Sql2Scanner
      */
     public function getPreviousDelimiter()
     {
-
-        return isset($this->delimiters[$this->curpos - 1]) ? $this->delimiters[$this->curpos - 1] : ' ';
+        return isset($this->delimiters[$this->curpos - 1]) ? $this->delimiters[$this->curpos - 1] : '';
     }
 
     /**

--- a/src/PHPCR/Util/QOM/Sql2ToQomQueryConverter.php
+++ b/src/PHPCR/Util/QOM/Sql2ToQomQueryConverter.php
@@ -283,7 +283,7 @@ class Sql2ToQomQueryConverter
 
         $token = $this->scanner->lookupNextToken();
         if ($this->scanner->tokenIs($token, ',')) {
-            $this->scanner->fetchNextToken(); // consume the coma
+            $this->scanner->fetchNextToken(); // consume the comma
             $path = $this->parsePath();
         } else {
             $path = null;
@@ -797,11 +797,15 @@ class Sql2ToQomQueryConverter
         }
 
         if ($quoteString) {
+            if (1 == strlen($token)) {
+                $token .= $this->scanner->fetchNextToken();
+            }
             while (substr($token, -1) !== $quoteString) {
                 $nextToken = $this->scanner->fetchNextToken();
                 if ('' === $nextToken) {
                     break;
                 }
+
                 $token .= $this->scanner->getPreviousDelimiter();
                 $token .= $nextToken;
             }

--- a/tests/PHPCR/Tests/Util/QOM/Sql2ToQomQueryConverterTest.php
+++ b/tests/PHPCR/Tests/Util/QOM/Sql2ToQomQueryConverterTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace PHPCR\Tests\Util\QOM;
+
+use PHPCR\Query\QOM\QueryObjectModelFactoryInterface;
+use PHPCR\Util\QOM\QueryBuilder;
+use PHPCR\Util\QOM\Sql2Scanner;
+use PHPCR\Util\QOM\Sql2ToQomQueryConverter;
+
+class Sql2ToQomQueryConverterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var QueryObjectModelFactoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $qf;
+
+    public function setUp()
+    {
+        $this->qf = $this->getMock('\PHPCR\Query\QOM\QueryObjectModelFactoryInterface');
+    }
+
+    public function literals()
+    {
+        return array(
+            array('".."', '..'),
+            array('"foo & bar&baz"', 'foo & bar&baz'),
+        );
+    }
+
+    /**
+     * @dataProvider literals
+     */
+    public function testParseLiteral($query, $parsed)
+    {
+        $this->qf->expects($this->once())
+            ->method('literal')
+            ->with($parsed)
+            ->will($this->returnValue(true))
+        ;
+
+        $converter = new Sql2ToQomQueryConverter($this->qf);
+        $scanner = new Sql2Scanner($query);
+        $ref = new \ReflectionClass('PHPCR\Util\QOM\Sql2ToQomQueryConverter');
+        $scannerProp = $ref->getProperty('scanner');
+        $scannerProp->setAccessible(true);
+        $scannerProp->setValue($converter, $scanner);
+        $parseLiteral = $ref->getMethod('parseLiteral');
+        $parseLiteral->setAccessible(true);
+        $this->assertTrue($parseLiteral->invoke($converter));
+    }
+}


### PR DESCRIPTION
it seems we have an issue parsing literals that immediately start with other delimiter tokens, like `".."`.

this looks good, however one of the tests in jackalope-doctrine-dbal fails.
