### PR TITLE
Refactored node type register command to be more flexible re. loading

### DIFF
--- a/tests/PHPCR/Tests/Util/Console/Command/NodeTypeRegisterCommandTest.php
+++ b/tests/PHPCR/Tests/Util/Console/Command/NodeTypeRegisterCommandTest.php
@@ -16,7 +16,7 @@ class NodeTypeRegisterCommandTest extends BaseCommandTest
         )->disableOriginalConstructor()->getMock();
     }
 
-    public function testNodeTypeList()
+    public function testNodeTypeRegister()
     {
         $this->session->expects($this->once())
             ->method('getWorkspace')
@@ -28,7 +28,7 @@ class NodeTypeRegisterCommandTest extends BaseCommandTest
             ->method('registerNodeTypesCnd');
 
         $ct = $this->executeCommand('phpcr:node-type:register', array(
-    'cnd-file' => __DIR__.'/fixtures/cnd_dummy.cnd',
+    'cnd-file' => array(__DIR__.'/fixtures/cnd_dummy.cnd'),
         ));
     }
 }


### PR DESCRIPTION
This PR:
- Allow multiple files to be specified
- Allow folders to be specified

Its a BC break in that it forces at least one `target` option to be secified, whereas before there was a required argument for a single CND file.

This PR also keeps in mind support for YAML files instead of CND (I am currently working on a YAML importer + dumper).
