### PR TITLE
[CND PARSER] Fixed parsing bug

### DIFF
--- a/src/PHPCR/Util/CND/Parser/CndParser.php
+++ b/src/PHPCR/Util/CND/Parser/CndParser.php
@@ -672,6 +672,12 @@ class CndParser extends AbstractParser
 
         while (true) {
             $token = $this->tokenQueue->peek();
+
+            // If there are no more tokens, break
+            if (!$token) {
+                break;
+            }
+
             $type = $token->getType();
             $data = $token->getData();
 


### PR DESCRIPTION
Do not crash if no more tokens after supertype declration..

Currently token peek returns the next token and then we get the type of the token, however if you declare a supertype for a node definition but do not define anything after, `peek` returns null and we get a fatal error when trying to access `null` as an object.

e.g.

```
<slinp = "http://slinp.com/ns/1.0">

[slinp:resource] > mix:created, mix:lastModified, nt:base
abstract
+ * (slinp:resource)

[slinp:webFolder] > nt:base
+ root (slinp:resource)

[slinp:root] > nt:base
+ web (slinp:webFolder) = slinp:webFolder autocreated

[slinp:article] > slinp:resource
```

Would crash the parser.
