### PR TITLE
escape fulltext search literal when converting from QOM to SQL2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.1.1
+-----
+
+* **2014-06-11**: handle escaping fulltext search literal when converting from/to QOM/SQL2
+
 1.1.0
 -----
 

--- a/src/PHPCR/Util/QOM/BaseQomToSqlQueryConverter.php
+++ b/src/PHPCR/Util/QOM/BaseQomToSqlQueryConverter.php
@@ -171,9 +171,8 @@ abstract class BaseQomToSqlQueryConverter
         if ($expr instanceof QOM\BindVariableValueInterface) {
             return $this->convertBindVariable($expr);
         }
-        if ($expr instanceof QOM\LiteralInterface) {
-            return $this->convertLiteral($expr);
-        }
+
+        $expr = $this->generator->evalFullText($expr);
 
         return "'$expr'";
     }

--- a/src/PHPCR/Util/QOM/BaseSqlGenerator.php
+++ b/src/PHPCR/Util/QOM/BaseSqlGenerator.php
@@ -218,6 +218,26 @@ abstract class BaseSqlGenerator
     }
 
     /**
+     * Escape the illegal characters for inclusion in a fulltext statement. Escape Character is \\.
+     *
+     * @param string $string
+     *
+     * @return string Escaped String
+     *
+     * @see http://jackrabbit.apache.org/api/1.4/org/apache/jackrabbit/util/Text.html #escapeIllegalJcrChars
+     */
+    public function evalFullText($string)
+    {
+        $illegalCharacters = array(
+            '!' => '\\!', '(' => '\\(', ':' => '\\:', '^' => '\\^',
+            '[' => '\\[', ']' => '\\]', '{' => '\\{', '}' => '\\}',
+            '\"' => '\\\"', '?' => '\\?', "'" => "''",
+        );
+
+        return strtr($string, $illegalCharacters);
+    }
+
+    /**
      * Literal ::= CastLiteral | UncastLiteral
      *
      * @param mixed $literal


### PR DESCRIPTION
what I am not sure here is if we should just escape the single quotes.
anything else should maybe be escaped when making the QOM instance automatically or manually before creating the QOM instance.

see https://github.com/phpcr/phpcr-api-tests/pull/136
