### PR TITLE
Fixed parser so that square brackets count as delimiters

### DIFF
--- a/src/PHPCR/Util/QOM/Sql2Scanner.php
+++ b/src/PHPCR/Util/QOM/Sql2Scanner.php
@@ -184,7 +184,7 @@ class Sql2Scanner
         $buffer = '';
         for ($i = 0; $i < strlen($token); $i++) {
             $char = trim(substr($token, $i, 1));
-            if (in_array($char, array('.', ',', '(', ')', '='))) {
+            if (in_array($char, array('[', ']', '.', ',', '(', ')', '='))) {
                 if ($buffer !== '') {
                     $tokens[] = $buffer;
                     $buffer = '';

--- a/src/PHPCR/Util/QOM/Sql2ToQomQueryConverter.php
+++ b/src/PHPCR/Util/QOM/Sql2ToQomQueryConverter.php
@@ -789,6 +789,10 @@ class Sql2ToQomQueryConverter
             return $this->parseCastLiteral($token);
         }
 
+        if ($this->scanner->tokenIs($token, 'NULL')) {
+            return null;
+        }
+
         $quoteString = false;
         if (substr($token, 0, 1) === '\'') {
             $quoteString = "'";
@@ -935,9 +939,9 @@ class Sql2ToQomQueryConverter
     {
         $token = $this->scanner->fetchNextToken();
 
-        if (substr($token, 0, 1) === '[' && substr($token, -1) === ']') {
-            // Remove brackets around the selector name
-            $token = substr($token, 1, -1);
+        if ($token === '[') {
+            $token = $this->scanner->fetchNextToken();
+            $this->scanner->expectToken(']');
         }
 
         return $token;


### PR DESCRIPTION
This is an "enabling" improvement which allows me to use the parser to parse things like:

```
UPDATE [foo] SET foo = ['foo','bar',baz'];
```

Square brackets _are_ delimiters in JCR-SQL2 (right?) so I think this is valid without compromise.
