### PR TITLE
Revert "Fixed parser so that square brackets count as delimiters"

### DIFF
--- a/src/PHPCR/Util/QOM/Sql2Scanner.php
+++ b/src/PHPCR/Util/QOM/Sql2Scanner.php
@@ -184,7 +184,7 @@ class Sql2Scanner
         $buffer = '';
         for ($i = 0; $i < strlen($token); $i++) {
             $char = trim(substr($token, $i, 1));
-            if (in_array($char, array('[', ']', '.', ',', '(', ')', '='))) {
+            if (in_array($char, array('.', ',', '(', ')', '='))) {
                 if ($buffer !== '') {
                     $tokens[] = $buffer;
                     $buffer = '';

--- a/src/PHPCR/Util/QOM/Sql2ToQomQueryConverter.php
+++ b/src/PHPCR/Util/QOM/Sql2ToQomQueryConverter.php
@@ -789,10 +789,6 @@ class Sql2ToQomQueryConverter
             return $this->parseCastLiteral($token);
         }
 
-        if ($this->scanner->tokenIs($token, 'NULL')) {
-            return null;
-        }
-
         $quoteString = false;
         if (substr($token, 0, 1) === '\'') {
             $quoteString = "'";
@@ -939,9 +935,9 @@ class Sql2ToQomQueryConverter
     {
         $token = $this->scanner->fetchNextToken();
 
-        if ($token === '[') {
-            $token = $this->scanner->fetchNextToken();
-            $this->scanner->expectToken(']');
+        if (substr($token, 0, 1) === '[' && substr($token, -1) === ']') {
+            // Remove brackets around the selector name
+            $token = substr($token, 1, -1);
         }
 
         return $token;


### PR DESCRIPTION
This reverts commit 389396bd7aa1d9cbf7d473908612a4695c7cbcaf.

This breaks stuff with no gain re. the specification.

I think the query parser should ultimately tokenize everything, but that would be a rewrite.

Fixes https://github.com/phpcr/phpcr-utils/issues/131
