### PR TITLE
always show the full path for the top level node in the dump

### DIFF
--- a/src/PHPCR/Util/Console/Helper/TreeDumper/ConsoleDumperNodeVisitor.php
+++ b/src/PHPCR/Util/Console/Helper/TreeDumper/ConsoleDumperNodeVisitor.php
@@ -21,6 +21,11 @@ class ConsoleDumperNodeVisitor extends ConsoleDumperItemVisitor
     protected $identifiers;
 
     /**
+     * Show the full path for the node
+     */
+    protected $showFullPath;
+
+    /**
      * Instantiate the console dumper visitor
      *
      * @param OutputInterface $output
@@ -30,6 +35,16 @@ class ConsoleDumperNodeVisitor extends ConsoleDumperItemVisitor
     {
         parent::__construct($output);
         $this->identifiers = $identifiers;
+    }
+
+    /**
+     * If to show the full path or not
+     *
+     * @param bool $showFullPath
+     */
+    public function setShowFullPath($showFullPath)
+    {
+        $this->showFullPath = $showFullPath;
     }
 
     /**
@@ -43,10 +58,12 @@ class ConsoleDumperNodeVisitor extends ConsoleDumperItemVisitor
             throw new \Exception("Internal error: did not expect to visit a non-node object: $item");
         }
 
-        $name = $item->getName();
-
         if ($item->getDepth() == 0) {
             $name = 'ROOT';
+        } else if ($this->showFullPath) {
+            $name = $item->getPath();
+        } else {
+            $name = $item->getName();
         }
 
         $out = str_repeat('  ', $this->level)

--- a/src/PHPCR/Util/TreeWalker.php
+++ b/src/PHPCR/Util/TreeWalker.php
@@ -129,6 +129,7 @@ class TreeWalker
 
             // Visit node
             $this->nodeVisitor->setLevel($level);
+            $this->nodeVisitor->setShowFullPath(0 === $level);
             $node->accept($this->nodeVisitor);
 
             // Visit properties


### PR DESCRIPTION
maybe the better more sensible approach to https://github.com/phpcr/phpcr-utils/pull/147