### PR TITLE
adjust commands for symfony 3 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+1.2.7
+-----
+
+* **2015-07-13**: Added Symfony 3 compatibility for the console commands. If you use
+  the commands, update your `cli-config.php` according to `cli-config.php.dist` to set
+  the question helper if it is available.
+
 1.2.0
 -----
 

--- a/cli-config.php.dist
+++ b/cli-config.php.dist
@@ -28,8 +28,13 @@ if (isset($argv[1])
     $session = $repository->login($credentials, $workspace);
 
     $helperSet = new \Symfony\Component\Console\Helper\HelperSet(array(
-        'dialog' => new \Symfony\Component\Console\Helper\DialogHelper(),
         'phpcr' => new \PHPCR\Util\Console\Helper\PhpcrHelper($session),
         'phpcr_console_dumper' => new \PHPCR\Util\Console\Helper\PhpcrConsoleDumperHelper(),
     ));
+
+    if (class_exists('Symfony\Component\Console\Helper\QuestionHelper')) {
+        $helperSet->set(new \Symfony\Component\Console\Helper\QuestionHelper(), 'question');
+    } else {
+        $helperSet->set(new \Symfony\Component\Console\Helper\DialogHelper(), 'dialog');
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": ">=5.3.3",
         "phpcr/phpcr": "~2.1.0",
-        "symfony/console": "2.*,>=2.0.5"
+        "symfony/console": "~2.3|~3.0"
     },
     "conflict": {
         "jackalope/jackalope-jackrabbit": "<1.2.1"

--- a/src/PHPCR/Util/Console/Command/BaseCommand.php
+++ b/src/PHPCR/Util/Console/Command/BaseCommand.php
@@ -4,12 +4,13 @@ namespace PHPCR\Util\Console\Command;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use PHPCR\SessionInterface;
 use PHPCR\Util\Console\Helper\PhpcrHelper;
 use PHPCR\Util\Console\Helper\PhpcrConsoleDumperHelper;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\Question;
 
 /**
  * Common base class to help with the helpers.
@@ -44,5 +45,47 @@ abstract class BaseCommand extends Command
     protected function getPhpcrConsoleDumperHelper()
     {
         return $this->getHelperSet()->get('phpcr_console_dumper');
+    }
+
+    /**
+     * Ask a question with the question helper or the dialog helper for symfony < 2.5 compatibility.
+     *
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     * @param string          $question
+     * @param string          $default
+     *
+     * @return string
+     */
+    protected function ask(InputInterface $input, OutputInterface $output, $question, $default = null)
+    {
+        if ($this->getHelperSet()->has('question')) {
+            $question = new Question($question, $default);
+
+            return $this->getHelper('question')->ask($input, $output, $question);
+        }
+
+        return $this->getHelper('dialog')->ask($output, $question, $default);
+    }
+
+    /**
+     * Ask for confirmation with the question helper or the dialog helper for symfony < 2.5 compatibility.
+     *
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     * @param string          $question
+     * @param boolean         $default
+     *
+     * @return string
+     */
+    protected function askConfirmation(InputInterface $input, OutputInterface $output, $question, $default = true)
+    {
+        if ($this->getHelperSet()->has('question')) {
+            $question = new ConfirmationQuestion($question, $default);
+
+            return $this->getHelper('question')->ask($input, $output, $question);
+        }
+
+        return $this->getHelper('dialog')->askConfirmation($output, $question, $default);
     }
 }

--- a/src/PHPCR/Util/Console/Command/NodeRemoveCommand.php
+++ b/src/PHPCR/Util/Console/Command/NodeRemoveCommand.php
@@ -3,13 +3,10 @@
 namespace PHPCR\Util\Console\Command;
 
 use PHPCR\NodeInterface;
-use PHPCR\SessionInterface;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Helper\DialogHelper;
 
 /**
  * Command to remove all nodes from a path in the workspace of the configured
@@ -73,8 +70,6 @@ EOF
         }
 
         if (!$force) {
-            /** @var $dialog DialogHelper */
-            $dialog = $this->getHelperSet()->get('dialog');
             $workspaceName = $session->getWorkspace()->getName();
 
             if ($onlyChildren) {
@@ -87,9 +82,12 @@ EOF
                     'from workspace "%s"';
             }
 
-            $force = $dialog->askConfirmation($output, sprintf(
-                '<question>'.$question.' Y/N ?</question>', $path, $workspaceName, false
-            ));
+            $force = $this->askConfirmation(
+                $input,
+                $output,
+                sprintf('<question>'.$question.' Y/N ?</question>', $path, $workspaceName),
+                false
+            );
         }
 
         if (!$force) {

--- a/src/PHPCR/Util/Console/Command/WorkspaceDeleteCommand.php
+++ b/src/PHPCR/Util/Console/Command/WorkspaceDeleteCommand.php
@@ -3,9 +3,6 @@
 namespace PHPCR\Util\Console\Command;
 
 use PHPCR\RepositoryInterface;
-use PHPCR\SessionInterface;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Helper\DialogHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -71,9 +68,7 @@ EOT
 
         $force = $input->getOption('force');
         if (!$force) {
-            /** @var $dialog DialogHelper */
-            $dialog = $this->getHelperSet()->get('dialog');
-            $force = $dialog->askConfirmation($output, sprintf(
+            $force = $this->askConfirmation($input, $output, sprintf(
                 '<question>Are you sure you want to delete workspace "%s" Y/N ?</question>',
                 $workspaceName
             ), false);

--- a/src/PHPCR/Util/Console/Command/WorkspacePurgeCommand.php
+++ b/src/PHPCR/Util/Console/Command/WorkspacePurgeCommand.php
@@ -2,12 +2,9 @@
 
 namespace PHPCR\Util\Console\Command;
 
-use PHPCR\SessionInterface;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Helper\DialogHelper;
 
 use PHPCR\Util\NodeHelper;
 
@@ -51,9 +48,7 @@ EOF
 
         $workspaceName = $session->getWorkspace()->getName();
         if (!$force) {
-            /** @var $dialog DialogHelper */
-            $dialog = $this->getHelperSet()->get('dialog');
-            $force = $dialog->askConfirmation($output, sprintf(
+            $force = $this->askConfirmation($input, $output, sprintf(
                 '<question>Are you sure you want to purge workspace "%s" Y/N ?</question>',
                 $workspaceName
             ), false);


### PR DESCRIPTION
The DialogHelper was deprecated in favour of QuestionHelper in symfony 2.5.

Also cleaning up some unused use statements.