### PR TITLE
always quote property name if not already quoted

### DIFF
--- a/src/PHPCR/Util/QOM/Sql2Generator.php
+++ b/src/PHPCR/Util/QOM/Sql2Generator.php
@@ -295,7 +295,7 @@ class Sql2Generator extends BaseSqlGenerator
     public function evalPropertyValue($propertyName, $selectorName = null)
     {
         $sql2 = null !== $selectorName ? $this->addBracketsIfNeeded($selectorName) . '.' : '';
-        if (false !== strpos($propertyName, ':')) {
+        if (substr($propertyName, 0, 1) !== '[') {
             $propertyName = "[$propertyName]";
         }
         $sql2 .= $propertyName;

--- a/src/PHPCR/Util/QOM/Sql2Generator.php
+++ b/src/PHPCR/Util/QOM/Sql2Generator.php
@@ -295,7 +295,7 @@ class Sql2Generator extends BaseSqlGenerator
     public function evalPropertyValue($propertyName, $selectorName = null)
     {
         $sql2 = null !== $selectorName ? $this->addBracketsIfNeeded($selectorName) . '.' : '';
-        if (substr($propertyName, 0, 1) !== '[') {
+        if ('*' !== $propertyName && substr($propertyName, 0, 1) !== '[') {
             $propertyName = "[$propertyName]";
         }
         $sql2 .= $propertyName;

--- a/tests/PHPCR/Tests/Util/QOM/Sql2GeneratorTest.php
+++ b/tests/PHPCR/Tests/Util/QOM/Sql2GeneratorTest.php
@@ -46,41 +46,41 @@ class Sql2GeneratorTest extends BaseSqlGeneratorTest
 
     public function testChildNode()
     {
-        $literal = $this->generator->evalChildNode("/foo/bar/baz");
-        $this->assertSame("ISCHILDNODE(/foo/bar/baz)", $literal);
+        $literal = $this->generator->evalChildNode('/foo/bar/baz');
+        $this->assertSame('ISCHILDNODE(/foo/bar/baz)', $literal);
     }
 
     public function testDescendantNode()
     {
-        $literal = $this->generator->evalDescendantNode("/foo/bar/baz");
-        $this->assertSame("ISDESCENDANTNODE(/foo/bar/baz)", $literal);
+        $literal = $this->generator->evalDescendantNode('/foo/bar/baz');
+        $this->assertSame('ISDESCENDANTNODE(/foo/bar/baz)', $literal);
     }
 
     public function testPopertyExistence()
     {
-        $literal = $this->generator->evalPropertyExistence(null, "foo");
-        $this->assertSame("foo IS NOT NULL", $literal);
+        $literal = $this->generator->evalPropertyExistence(null, 'foo');
+        $this->assertSame('[foo] IS NOT NULL', $literal);
     }
 
     public function testFullTextSearch()
     {
-        $literal = $this->generator->evalFullTextSearch("data", "'foo'");
+        $literal = $this->generator->evalFullTextSearch('data', "'foo'");
         $this->assertSame("CONTAINS(data.*, 'foo')", $literal);
-        $literal = $this->generator->evalFullTextSearch("data", "'foo'", "bar");
-        $this->assertSame("CONTAINS(data.bar, 'foo')", $literal);
+        $literal = $this->generator->evalFullTextSearch('data', "'foo'", 'bar');
+        $this->assertSame("CONTAINS(data.[bar], 'foo')", $literal);
     }
 
     public function testColumns()
     {
         $literal = $this->generator->evalColumns(null);
-        $this->assertSame("*", $literal);
-        $literal = $this->generator->evalColumns(array("bar", "foo"));
-        $this->assertSame("bar, foo", $literal);
+        $this->assertSame('*', $literal);
+        $literal = $this->generator->evalColumns(array('bar', 'foo'));
+        $this->assertSame('bar, foo', $literal);
     }
 
     public function testPropertyValue()
     {
-        $literal = $this->generator->evalPropertyValue("foo");
-        $this->assertSame("foo", $literal);
+        $literal = $this->generator->evalPropertyValue('foo');
+        $this->assertSame('[foo]', $literal);
     }
 }


### PR DESCRIPTION
i noticed that a property with hyphens fails otherwise. its valid to put [] around every property, so lets play it safe.