### PR TITLE
fixes jackalope/jackalope-doctrine-dbal#298

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ valid UUID.
 We recommend all implementations to use this implementation to guarantee
 consistent behaviour.
 
+**Note**
+
+You can use [ramsey/uuid](https://github.com/ramsey/uuid) library to generate UUIDs. In this case,
+install it using Composer and generating UUIDs will be taken over by `ramsey/uuid`.
+
 ### QOM QueryBuilder
 
 The ``QueryBuilder`` is a fluent query builder with method names matching the

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     "require": {
         "php": ">=5.3.3",
         "phpcr/phpcr": "~2.1.0",
-        "symfony/console": "~2.3|~3.0"
+        "symfony/console": "~2.3|~3.0",
+        "ramsey/uuid": "~2.8"
     },
     "conflict": {
         "jackalope/jackalope-jackrabbit": "<1.2.1"

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,10 @@
     "require": {
         "php": ">=5.3.3",
         "phpcr/phpcr": "~2.1.0",
-        "symfony/console": "~2.3|~3.0",
-        "ramsey/uuid": "~2.8"
+        "symfony/console": "~2.3|~3.0"
+    },
+    "suggest": {
+        "ramsey/uuid": "A PHP 5.4+ library for generating RFC 4122 version 1, 3, 4, and 5 universally unique identifiers (UUID)."
     },
     "conflict": {
         "jackalope/jackalope-jackrabbit": "<1.2.1"

--- a/src/PHPCR/Util/UUIDHelper.php
+++ b/src/PHPCR/Util/UUIDHelper.php
@@ -2,6 +2,8 @@
 
 namespace PHPCR\Util;
 
+use Rhumsaa\Uuid\Uuid;
+
 /**
  * Static helper functions to deal with Universally Unique IDs (UUID).
  *
@@ -13,8 +15,9 @@ class UUIDHelper
     /**
      * Checks if the string could be a UUID.
      *
-     * @param  string  $id Possible uuid
-     * @return boolean True if the test was passed, else false.
+     * @param string $id Possible uuid
+     *
+     * @return bool True if the test was passed, else false.
      */
     public static function isUUID($id)
     {
@@ -29,31 +32,12 @@ class UUIDHelper
     /**
      * Generate a UUID.
      *
-     * This UUID can not be guaranteed to be unique within the repository.
-     * Ensuring this is the responsibility of the repository implementation.
-     *
      * @return string a random UUID
      */
     public static function generateUUID()
     {
-        return sprintf('%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
-            // 32 bits for "time_low"
-            mt_rand(0, 0xffff), mt_rand(0, 0xffff),
+        $uuid4 = Uuid::uuid4();
 
-            // 16 bits for "time_mid"
-            mt_rand(0, 0xffff),
-
-            // 16 bits for "time_hi_and_version",
-            // four most significant bits holds version number 4
-            mt_rand(0, 0x0fff) | 0x4000,
-
-            // 16 bits, 8 bits for "clk_seq_hi_res",
-            // 8 bits for "clk_seq_low",
-            // two most significant bits holds zero and one for variant DCE1.1
-            mt_rand(0, 0x3fff) | 0x8000,
-
-            // 48 bits for "node"
-            mt_rand(0, 0xffff), mt_rand(0, 0xffff), mt_rand(0, 0xffff)
-        );
+        return $uuid4->toString();
     }
 }

--- a/src/PHPCR/Util/UUIDHelper.php
+++ b/src/PHPCR/Util/UUIDHelper.php
@@ -2,7 +2,7 @@
 
 namespace PHPCR\Util;
 
-use Rhumsaa\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 
 /**
  * Static helper functions to deal with Universally Unique IDs (UUID).
@@ -32,12 +32,39 @@ class UUIDHelper
     /**
      * Generate a UUID.
      *
+     * This UUID can not be guaranteed to be unique within the repository.
+     * Ensuring this is the responsibility of the repository implementation.
+     *
+     * It also allows the use of Ramsey\Uuid\Uuid class.
+     *
      * @return string a random UUID
      */
     public static function generateUUID()
     {
-        $uuid4 = Uuid::uuid4();
+        if (class_exists('Ramsey\Uuid\Uuid')) {
+            $uuid4 = Uuid::uuid4();
 
-        return $uuid4->toString();
+            return $uuid4->toString();
+        }
+
+        return sprintf('%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
+            // 32 bits for "time_low"
+            mt_rand(0, 0xffff), mt_rand(0, 0xffff),
+
+            // 16 bits for "time_mid"
+            mt_rand(0, 0xffff),
+
+            // 16 bits for "time_hi_and_version",
+            // four most significant bits holds version number 4
+            mt_rand(0, 0x0fff) | 0x4000,
+
+            // 16 bits, 8 bits for "clk_seq_hi_res",
+            // 8 bits for "clk_seq_low",
+            // two most significant bits holds zero and one for variant DCE1.1
+            mt_rand(0, 0x3fff) | 0x8000,
+
+            // 48 bits for "node"
+            mt_rand(0, 0xffff), mt_rand(0, 0xffff), mt_rand(0, 0xffff)
+        );
     }
 }


### PR DESCRIPTION
fixes jackalope/jackalope-doctrine-dbal#298

Even better will be to use [rhumsaa/uuid](https://github.com/ramsey/uuid) library, imho (so I added it). `openssl_random_pseudo_bytes` function was failing on PHP 5.3.3.

Thus, this PR also fixes #120