### PR TITLE
stop building on broken 5.3.3 setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
@@ -14,7 +13,7 @@ sudo: false
 
 matrix:
   include:
-    - php: 5.3.3
+    - php: 5.3
       env: PACKAGE_VERSION=low
 
 before_script:


### PR DESCRIPTION
minimum version build is still 5.3, but not 5.3.3 as that one has a broken ssl setup.