### PR TITLE
syntax was updated to PHP 5.6 (::class string, short array syntax etc.)

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,5 +1,5 @@
 preset: psr2
 
 enabled:
-  - long_array_syntax
+  - short_array_syntax
   - duplicate_semicolon

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
   - if [[ "$PACKAGE_VERSION" == "high" ]]; then composer update --prefer-source; fi
   - if [[ "$PACKAGE_VERSION" == "low" ]]; then composer update --prefer-lowest --prefer-source; fi
 
-script: phpunit -c tests/phpunit.xml.dist
+script: php vendor/bin/phpunit -c tests/phpunit.xml.dist
 
 notifications:
   irc: "irc.freenode.org#jackalope"

--- a/bin/phpcr
+++ b/bin/phpcr
@@ -5,7 +5,7 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Helper\HelperSet;
 use PHPCR\Util\Console\Command;
 
-if (!class_exists('\Symfony\Component\Console\Application')) {
+if (!class_exists(Application::class)) {
     if (is_file(__DIR__.'/../vendor/autoload.php')) {
         require __DIR__.'/../vendor/autoload.php';
     } elseif (is_file(__DIR__.'/../../../autoload.php')) {
@@ -30,7 +30,7 @@ if (file_exists($configFile)) {
     require $configFile;
 
     foreach ($GLOBALS as $helperSetCandidate) {
-        if ($helperSetCandidate instanceof \Symfony\Component\Console\Helper\HelperSet) {
+        if ($helperSetCandidate instanceof HelperSet) {
             $helperSet = $helperSetCandidate;
             break;
         }
@@ -48,7 +48,7 @@ $cli = new Application('PHPCR Command Line Interface', '0.1');
 $cli->setCatchExceptions(true);
 $cli->setHelperSet($helperSet);
 
-$cli->addCommands(array(
+$cli->addCommands([
     new Command\NodeDumpCommand(),
     new Command\NodeMoveCommand(),
     new Command\NodeRemoveCommand(),
@@ -62,7 +62,7 @@ $cli->addCommands(array(
     new Command\WorkspaceImportCommand(),
     new Command\WorkspacePurgeCommand(),
     new Command\WorkspaceQueryCommand(),
-));
+]);
 
 $cli->run();
 

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,9 @@
         "symfony/console": "~2.3|~3.0"
     },
     "require-dev": {
-        "ramsey/uuid": "^3.5"
+        "ramsey/uuid": "^3.5",
+        "phpunit/phpunit": "^5.7",
+        "phpstan/phpstan": "^0.6.0"
     },
     "suggest": {
         "ramsey/uuid": "A PHP 5.4+ library for generating RFC 4122 version 1, 3, 4, and 5 universally unique identifiers (UUID)."

--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,7 @@
     },
     "require-dev": {
         "ramsey/uuid": "^3.5",
-        "phpunit/phpunit": "^5.7",
-        "phpstan/phpstan": "^0.6.0"
+        "phpunit/phpunit": "^5.7"
     },
     "suggest": {
         "ramsey/uuid": "A PHP 5.4+ library for generating RFC 4122 version 1, 3, 4, and 5 universally unique identifiers (UUID)."

--- a/src/PHPCR/Util/Console/Command/BaseNodeManipulationCommand.php
+++ b/src/PHPCR/Util/Console/Command/BaseNodeManipulationCommand.php
@@ -21,18 +21,22 @@ abstract class BaseNodeManipulationCommand extends BaseCommand
             InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
             'Set node property on nodes use foo=bar'
         );
+
         $this->addOption('remove-prop', 'r',
             InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
             'Remove property from nodes'
         );
+
         $this->addOption('add-mixin', null,
             InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
             'Add a mixin to the nodes'
         );
+
         $this->addOption('remove-mixin', null,
             InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
             'Remove mixin from the nodes'
         );
+
         $this->addOption('apply-closure', null,
             InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
             'Apply a closure to each node, closures are passed PHPCR\Session and PHPCR\NodeInterface'

--- a/src/PHPCR/Util/Console/Command/NodeDumpCommand.php
+++ b/src/PHPCR/Util/Console/Command/NodeDumpCommand.php
@@ -2,10 +2,12 @@
 
 namespace PHPCR\Util\Console\Command;
 
+use Exception;
 use PHPCR\ItemNotFoundException;
 use PHPCR\RepositoryException;
 use PHPCR\PathNotFoundException;
 use PHPCR\Util\UUIDHelper;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
@@ -24,6 +26,8 @@ class NodeDumpCommand extends BaseCommand
 {
     /**
      * {@inheritDoc}
+     *
+     * @throws InvalidArgumentException
      */
     protected function configure()
     {
@@ -54,6 +58,10 @@ HERE
 
     /**
      * {@inheritDoc}
+     *
+     * @throws InvalidArgumentException
+     * @throws Exception
+     * @throws RepositoryException
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -72,7 +80,7 @@ HERE
         $options['max_line_length'] = $input->getOption('max_line_length');
 
         if (null !== $options['ref_format'] && !in_array($options['ref_format'], array('uuid', 'path'))) {
-            throw new \Exception('The ref-format option must be set to either "path" or "uuid"');
+            throw new Exception('The ref-format option must be set to either "path" or "uuid"');
         }
 
         $walker = $dumperHelper->getTreeWalker($output, $options);

--- a/src/PHPCR/Util/Console/Command/NodeMoveCommand.php
+++ b/src/PHPCR/Util/Console/Command/NodeMoveCommand.php
@@ -3,6 +3,7 @@
 namespace PHPCR\Util\Console\Command;
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -19,6 +20,8 @@ class NodeMoveCommand extends BaseCommand
 {
     /**
      * {@inheritDoc}
+     *
+     * @throws InvalidArgumentException
      */
     protected function configure()
     {
@@ -42,6 +45,8 @@ EOF
 
     /**
      * {@inheritDoc}
+     *
+     * @throws InvalidArgumentException
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/PHPCR/Util/Console/Command/NodeRemoveCommand.php
+++ b/src/PHPCR/Util/Console/Command/NodeRemoveCommand.php
@@ -2,7 +2,9 @@
 
 namespace PHPCR\Util\Console\Command;
 
+use InvalidArgumentException;
 use PHPCR\NodeInterface;
+use Symfony\Component\Console\Exception\InvalidArgumentException as CliInvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
@@ -22,6 +24,8 @@ class NodeRemoveCommand extends BaseCommand
 {
     /**
      * {@inheritDoc}
+     *
+     * @throws CliInvalidArgumentException
      */
     protected function configure()
     {
@@ -51,6 +55,9 @@ EOF
 
     /**
      * {@inheritDoc}
+     *
+     * @throws CliInvalidArgumentException
+     * @throws InvalidArgumentException
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -63,7 +70,7 @@ EOF
         if ('/' === $path) {
             // even if we have only children, this will not work as we would
             // try to remove system nodes.
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Can not delete root node (path "/"), please use the '.
                 'workspace:purge command instead to purge the whole workspace.'
             );

--- a/src/PHPCR/Util/Console/Command/NodeTouchCommand.php
+++ b/src/PHPCR/Util/Console/Command/NodeTouchCommand.php
@@ -3,6 +3,7 @@
 namespace PHPCR\Util\Console\Command;
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -23,6 +24,8 @@ class NodeTouchCommand extends BaseNodeManipulationCommand
 {
     /**
      * {@inheritDoc}
+     *
+     * @throws InvalidArgumentException
      */
     protected function configure()
     {
@@ -68,6 +71,8 @@ HERE
 
     /**
      * {@inheritDoc}
+     *
+     * @throws InvalidArgumentException
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/PHPCR/Util/Console/Command/NodeTypeListCommand.php
+++ b/src/PHPCR/Util/Console/Command/NodeTypeListCommand.php
@@ -3,6 +3,7 @@
 namespace PHPCR\Util\Console\Command;
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/src/PHPCR/Util/Console/Command/NodeTypeRegisterCommand.php
+++ b/src/PHPCR/Util/Console/Command/NodeTypeRegisterCommand.php
@@ -130,7 +130,7 @@ EOT
      */
     protected function getFilePaths($definitions)
     {
-        $filePaths = array();
+        $filePaths = [];
 
         foreach ($definitions as $definition) {
             if (is_dir($definition)) {
@@ -167,7 +167,7 @@ EOT
 
     protected function fileIsNodeType($filename)
     {
-        if (substr($filename, -4) == '.cnd') {
+        if (substr($filename, -4) === '.cnd') {
             return true;
         }
 

--- a/src/PHPCR/Util/Console/Command/NodesUpdateCommand.php
+++ b/src/PHPCR/Util/Console/Command/NodesUpdateCommand.php
@@ -2,8 +2,10 @@
 
 namespace PHPCR\Util\Console\Command;
 
+use InvalidArgumentException;
 use PHPCR\Query\QueryResultInterface;
 use PHPCR\Query\RowInterface;
+use Symfony\Component\Console\Exception\InvalidArgumentException as CliInvalidArgumentException;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -21,6 +23,8 @@ class NodesUpdateCommand extends BaseNodeManipulationCommand
 {
     /**
      * {@inheritDoc}
+     *
+     * @throws CliInvalidArgumentException
      */
     protected function configure()
     {
@@ -79,12 +83,15 @@ HERE
 
     /**
      * {@inheritDoc}
+     *
+     * @throws CliInvalidArgumentException
+     * @throws InvalidArgumentException
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $query = $input->getOption('query');
         $queryLanguage = strtoupper($input->getOption('query-language'));
-        $persistCounter = intval($input->getOption('persist-counter'));
+        $persistCounter = (int) $input->getOption('persist-counter');
         $setProp = $input->getOption('set-prop');
         $removeProp = $input->getOption('remove-prop');
         $addMixins = $input->getOption('add-mixin');
@@ -95,16 +102,13 @@ HERE
         $session = $this->getPhpcrSession();
 
         if (!$query) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'You must provide a SELECT query, e.g. --query="SELECT * FROM [nt:unstructured]"'
             );
         }
 
-        if (strtoupper(substr($query, 0, 6)) != 'SELECT') {
-            throw new \InvalidArgumentException(sprintf(
-                'Query doesn\'t look like a SELECT query: "%s"',
-                $query
-            ));
+        if (strtoupper(substr($query, 0, 6)) !== 'SELECT') {
+            throw new InvalidArgumentException("Query doesn't look like a SELECT query: '$query'");
         }
 
         $query = $helper->createQuery($queryLanguage, $query);
@@ -161,7 +165,7 @@ HERE
             count($result->getRows())
         )));
 
-        if ($response == 'L') {
+        if ($response === 'L') {
             /** @var $row RowInterface */
             foreach ($result as $i => $row) {
                 $output->writeln(sprintf(' - [%d] %s', $i, $row->getPath()));
@@ -170,11 +174,11 @@ HERE
             return $this->shouldExecute($input, $output, $result);
         }
 
-        if ($response == 'N') {
+        if ($response === 'N') {
             return false;
         }
 
-        if ($response == 'Y') {
+        if ($response === 'Y') {
             return true;
         }
 

--- a/src/PHPCR/Util/Console/Command/WorkspaceCreateCommand.php
+++ b/src/PHPCR/Util/Console/Command/WorkspaceCreateCommand.php
@@ -3,8 +3,6 @@
 namespace PHPCR\Util\Console\Command;
 
 use PHPCR\RepositoryInterface;
-use PHPCR\SessionInterface;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/PHPCR/Util/Console/Command/WorkspaceExportCommand.php
+++ b/src/PHPCR/Util/Console/Command/WorkspaceExportCommand.php
@@ -2,7 +2,6 @@
 
 namespace PHPCR\Util\Console\Command;
 
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/PHPCR/Util/Console/Command/WorkspaceImportCommand.php
+++ b/src/PHPCR/Util/Console/Command/WorkspaceImportCommand.php
@@ -2,7 +2,6 @@
 
 namespace PHPCR\Util\Console\Command;
 
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/PHPCR/Util/Console/Command/WorkspaceListCommand.php
+++ b/src/PHPCR/Util/Console/Command/WorkspaceListCommand.php
@@ -2,7 +2,6 @@
 
 namespace PHPCR\Util\Console\Command;
 
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/src/PHPCR/Util/Console/Command/WorkspaceQueryCommand.php
+++ b/src/PHPCR/Util/Console/Command/WorkspaceQueryCommand.php
@@ -2,7 +2,6 @@
 
 namespace PHPCR\Util\Console\Command;
 
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/PHPCR/Util/NodeHelper.php
+++ b/src/PHPCR/Util/NodeHelper.php
@@ -240,7 +240,7 @@ class NodeHelper
          * as a basis. The way in which the local name is constructed from the hint
          * may vary across implementations.
          */
-        $matches = array();
+        $matches = [];
         if (preg_match('#^\\{([^\\}]+)\\}([a-zA-Z][a-zA-Z0-9]*)$#', $nameHint, $matches)) {
             $ns = $matches[1];
             $name = $matches[2];
@@ -294,7 +294,7 @@ class NodeHelper
      */
     public static function calculateOrderBefore(array $old, array $new)
     {
-        $reorders = array();
+        $reorders = [];
 
         //check for deleted items
         $newIndex = array_flip($new);

--- a/src/PHPCR/Util/QOM/BaseQomToSqlQueryConverter.php
+++ b/src/PHPCR/Util/QOM/BaseQomToSqlQueryConverter.php
@@ -301,7 +301,8 @@ abstract class BaseQomToSqlQueryConverter
      */
     protected function convertColumns(array $columns)
     {
-        $list = array();
+        $list = [];
+
         /** @var $column QOM\ColumnInterface */
         foreach ($columns as $column) {
             $selector = $column->getSelectorName();

--- a/src/PHPCR/Util/QOM/BaseSqlGenerator.php
+++ b/src/PHPCR/Util/QOM/BaseSqlGenerator.php
@@ -2,6 +2,7 @@
 
 namespace PHPCR\Util\QOM;
 
+use DateTime;
 use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as Constants;
 use PHPCR\PropertyType;
 use PHPCR\Util\ValueConverter;
@@ -240,11 +241,11 @@ abstract class BaseSqlGenerator
      */
     public function evalFullText($string)
     {
-        $illegalCharacters = array(
+        $illegalCharacters = [
             '!' => '\\!', '(' => '\\(', ':' => '\\:', '^' => '\\^',
             '[' => '\\[', ']' => '\\]', '{' => '\\{', '}' => '\\}',
             '\"' => '\\\"', '?' => '\\?', "'" => "''",
-        );
+        ];
 
         return strtr($string, $illegalCharacters);
     }
@@ -258,7 +259,7 @@ abstract class BaseSqlGenerator
      */
     public function evalLiteral($literal)
     {
-        if ($literal instanceof \DateTime) {
+        if ($literal instanceof DateTime) {
             $string = $this->valueConverter->convertType($literal, PropertyType::STRING);
 
             return $this->evalCastLiteral($string, 'DATE');

--- a/src/PHPCR/Util/QOM/QomToSql1QueryConverter.php
+++ b/src/PHPCR/Util/QOM/QomToSql1QueryConverter.php
@@ -18,6 +18,8 @@ class QomToSql1QueryConverter extends BaseQomToSqlQueryConverter
      *
      * @param  QOM\SourceInterface $source
      * @return string
+     *
+     * @throws InvalidArgumentException
      */
     protected function convertSource(QOM\SourceInterface $source)
     {
@@ -51,29 +53,36 @@ class QomToSql1QueryConverter extends BaseQomToSqlQueryConverter
                 $this->convertConstraint($constraint->getConstraint1()),
                 $this->convertConstraint($constraint->getConstraint2()));
         }
+
         if ($constraint instanceof QOM\OrInterface) {
             return $this->generator->evalOr(
                 $this->convertConstraint($constraint->getConstraint1()),
                 $this->convertConstraint($constraint->getConstraint2()));
         }
+
         if ($constraint instanceof QOM\NotInterface) {
             return $this->generator->evalNot($this->convertConstraint($constraint->getConstraint()));
         }
+
         if ($constraint instanceof QOM\ComparisonInterface) {
             return $this->convertComparison($constraint);
         }
+
         if ($constraint instanceof QOM\PropertyExistenceInterface) {
             return $this->convertPropertyExistence($constraint);
         } elseif ($constraint instanceof QOM\FullTextSearchInterface) {
             return $this->convertFullTextSearch($constraint);
         }
+
         if ($constraint instanceof QOM\SameNodeInterface) {
             throw new NotSupportedConstraintException($constraint);
         }
+
         if ($constraint instanceof QOM\ChildNodeInterface) {
             return $this->generator->evalChildNode(
                 $this->convertPath($constraint->getParentPath()));
         }
+
         if ($constraint instanceof QOM\DescendantNodeInterface) {
             return $this->generator->evalDescendantNode(
                 $this->convertPath($constraint->getAncestorPath()));
@@ -102,23 +111,29 @@ class QomToSql1QueryConverter extends BaseQomToSqlQueryConverter
         if ($operand instanceof QOM\PropertyValueInterface) {
             return $this->convertPropertyValue($operand);
         }
+
         if ($operand instanceof QOM\LengthInterface) {
             throw new NotSupportedOperandException($operand);
         }
+
         if ($operand instanceof QOM\NodeNameInterface) {
             throw new NotSupportedOperandException($operand);
         }
+
         if ($operand instanceof QOM\NodeLocalNameInterface) {
             throw new NotSupportedOperandException($operand);
         }
+
         if ($operand instanceof QOM\FullTextSearchScoreInterface) {
             throw new NotSupportedOperandException($operand);
         }
+
         if ($operand instanceof QOM\LowerCaseInterface) {
             $operand = $this->convertDynamicOperand($operand->getOperand());
 
             return $this->generator->evalLower($operand);
         }
+
         if ($operand instanceof QOM\UpperCaseInterface) {
             $operand = $this->convertDynamicOperand($operand->getOperand());
 

--- a/src/PHPCR/Util/QOM/QomToSql2QueryConverter.php
+++ b/src/PHPCR/Util/QOM/QomToSql2QueryConverter.php
@@ -193,32 +193,39 @@ class QomToSql2QueryConverter extends BaseQomToSqlQueryConverter
                 $this->convertConstraint($constraint->getConstraint1()),
                 $this->convertConstraint($constraint->getConstraint2()));
         }
+
         if ($constraint instanceof QOM\OrInterface) {
             return $this->generator->evalOr(
                 $this->convertConstraint($constraint->getConstraint1()),
                 $this->convertConstraint($constraint->getConstraint2()));
         }
+
         if ($constraint instanceof QOM\NotInterface) {
             return $this->generator->evalNot($this->convertConstraint($constraint->getConstraint()));
         }
+
         if ($constraint instanceof QOM\ComparisonInterface) {
             return $this->convertComparison($constraint);
         }
+
         if ($constraint instanceof QOM\PropertyExistenceInterface) {
             return $this->convertPropertyExistence($constraint);
         } elseif ($constraint instanceof QOM\FullTextSearchInterface) {
             return $this->convertFullTextSearch($constraint);
         }
+
         if ($constraint instanceof QOM\SameNodeInterface) {
             return $this->generator->evalSameNode(
                 $this->convertPath($constraint->getPath()),
                 $constraint->getSelectorName());
         }
+
         if ($constraint instanceof QOM\ChildNodeInterface) {
             return $this->generator->evalChildNode(
                 $this->convertPath($constraint->getParentPath()),
                 $constraint->getSelectorName());
         }
+
         if ($constraint instanceof QOM\DescendantNodeInterface) {
             return $this->generator->evalDescendantNode(
                 $this->convertPath($constraint->getAncestorPath()),
@@ -252,6 +259,7 @@ class QomToSql2QueryConverter extends BaseQomToSqlQueryConverter
         if ($operand instanceof QOM\PropertyValueInterface) {
             return $this->convertPropertyValue($operand);
         }
+
         if ($operand instanceof QOM\LengthInterface) {
             return $this->generator->evalLength($this->convertPropertyValue($operand->getPropertyValue()));
         }
@@ -263,14 +271,17 @@ class QomToSql2QueryConverter extends BaseQomToSqlQueryConverter
         if ($operand instanceof QOM\NodeLocalNameInterface) {
             return $this->generator->evalNodeLocalName($operand->getSelectorName());
         }
+
         if ($operand instanceof QOM\FullTextSearchScoreInterface) {
             return $this->generator->evalFullTextSearchScore($operand->getSelectorName());
         }
+
         if ($operand instanceof QOM\LowerCaseInterface) {
             $operand = $this->convertDynamicOperand($operand->getOperand());
 
             return $this->generator->evalLower($operand);
         }
+
         if ($operand instanceof QOM\UpperCaseInterface) {
             $operand = $this->convertDynamicOperand($operand->getOperand());
 

--- a/src/PHPCR/Util/QOM/QueryBuilder.php
+++ b/src/PHPCR/Util/QOM/QueryBuilder.php
@@ -13,6 +13,7 @@ use PHPCR\Query\QOM\JoinConditionInterface;
 use PHPCR\Query\QOM\QueryObjectModelConstantsInterface;
 use PHPCR\Query\QueryInterface;
 use PHPCR\Query\QOM\QueryObjectModelInterface;
+use PHPCR\Query\QueryResultInterface;
 use RuntimeException;
 
 /**
@@ -54,7 +55,7 @@ class QueryBuilder
     /**
      * @var array with the orderings that determine the order of the result
      */
-    private $orderings = array();
+    private $orderings = [];
 
     /**
      * @var ConstraintInterface to apply to the query.
@@ -64,7 +65,7 @@ class QueryBuilder
     /**
      * @var array with the columns to be selected.
      */
-    private $columns = array();
+    private $columns = [];
 
     /**
      * @var SourceInterface source of the query.
@@ -81,7 +82,7 @@ class QueryBuilder
     /**
      * @var array The query parameters.
      */
-    private $params = array();
+    private $params = [];
 
     /**
      * Initializes a new QueryBuilder
@@ -216,7 +217,7 @@ class QueryBuilder
     {
         $order = strtoupper($order);
 
-        if (!in_array($order, array('ASC', 'DESC'))) {
+        if (!in_array($order, ['ASC', 'DESC'])) {
             throw new InvalidArgumentException('Order must be one of "ASC" or "DESC"');
         }
 
@@ -294,6 +295,7 @@ class QueryBuilder
     public function andWhere(ConstraintInterface $constraint)
     {
         $this->state = self::STATE_DIRTY;
+
         if ($this->constraint) {
             $this->constraint = $this->qomFactory->andConstraint($this->constraint, $constraint);
         } else {
@@ -323,6 +325,7 @@ class QueryBuilder
     public function orWhere(ConstraintInterface $constraint)
     {
         $this->state = self::STATE_DIRTY;
+
         if ($this->constraint) {
             $this->constraint = $this->qomFactory->orConstraint($this->constraint, $constraint);
         } else {
@@ -369,7 +372,7 @@ class QueryBuilder
     public function select($selectorName, $propertyName, $columnName = null)
     {
         $this->state = self::STATE_DIRTY;
-        $this->columns = array($this->qomFactory->column($selectorName, $propertyName, $columnName));
+        $this->columns = [$this->qomFactory->column($selectorName, $propertyName, $columnName)];
 
         return $this;
     }
@@ -386,6 +389,7 @@ class QueryBuilder
     public function addSelect($selectorName, $propertyName, $columnName = null)
     {
         $this->state = self::STATE_DIRTY;
+
         $this->columns[] = $this->qomFactory->column($selectorName, $propertyName, $columnName);
 
         return $this;
@@ -493,6 +497,7 @@ class QueryBuilder
         if (!$this->source) {
             throw new RuntimeException('Cannot perform a join without a previous call to from');
         }
+
         $this->state = self::STATE_DIRTY;
         $this->source = $this->qomFactory->join($this->source, $rightSource, $joinType, $joinCondition);
 
@@ -509,6 +514,7 @@ class QueryBuilder
         if ($this->query !== null && $this->state === self::STATE_CLEAN) {
             return $this->query;
         }
+
         $this->state = self::STATE_CLEAN;
         $this->query = $this->qomFactory->createQuery($this->source, $this->constraint, $this->orderings, $this->columns);
 
@@ -526,7 +532,7 @@ class QueryBuilder
     /**
      * Executes the query setting firstResult and maxResults.
      *
-     * @return \PHPCR\Query\QueryResultInterface
+     * @return QueryResultInterface
      */
     public function execute()
     {
@@ -538,9 +544,7 @@ class QueryBuilder
             $this->query->bindValue($key, $value);
         }
 
-        $queryResult = $this->query->execute();
-
-        return $queryResult;
+        return $this->query->execute();
     }
 
     /**

--- a/src/PHPCR/Util/QOM/Sql1Generator.php
+++ b/src/PHPCR/Util/QOM/Sql1Generator.php
@@ -2,8 +2,6 @@
 
 namespace PHPCR\Util\QOM;
 
-use PHPCR\Query\QOM;
-
 /**
  * Generate SQL1 statements.
  *
@@ -72,9 +70,8 @@ class Sql1Generator extends BaseSqlGenerator
     public function evalDescendantNode($path)
     {
         $path = $this->getPathForDescendantQuery($path);
-        $sql1 = "jcr:path LIKE '" . $path . "'";
 
-        return $sql1;
+        return "jcr:path LIKE '" . $path . "'";
     }
 
     /**

--- a/src/PHPCR/Util/QOM/Sql2Scanner.php
+++ b/src/PHPCR/Util/QOM/Sql2Scanner.php
@@ -156,14 +156,14 @@ class Sql2Scanner
      */
     protected function scan($sql2)
     {
-        $tokens = array();
+        $tokens = [];
         $token = strtok($sql2, " \n\t");
         while ($token !== false) {
             $this->tokenize($tokens, $token);
             $token = strtok(" \n\t");
         }
 
-        $regexpTokens = array();
+        $regexpTokens = [];
         foreach ($tokens as $token) {
             $regexpTokens[] = preg_quote($token, '/');
         }
@@ -187,7 +187,7 @@ class Sql2Scanner
         $buffer = '';
         for ($i = 0; $i < strlen($token); $i++) {
             $char = trim(substr($token, $i, 1));
-            if (in_array($char, array('.', ',', '(', ')', '='))) {
+            if (in_array($char, ['.', ',', '(', ')', '='])) {
                 if ($buffer !== '') {
                     $tokens[] = $buffer;
                     $buffer = '';

--- a/src/PHPCR/Util/QOM/Sql2ToQomQueryConverter.php
+++ b/src/PHPCR/Util/QOM/Sql2ToQomQueryConverter.php
@@ -150,7 +150,8 @@ class Sql2ToQomQueryConverter
 
         $next = $this->scanner->lookupNextToken();
         $left = $selector;
-        while (in_array(strtoupper($next), array('JOIN', 'INNER', 'RIGHT', 'LEFT'))) {
+
+        while (in_array(strtoupper($next), ['JOIN', 'INNER', 'RIGHT', 'LEFT'])) {
             $left = $this->parseJoin($left);
             $next = $this->scanner->lookupNextToken();
         }
@@ -317,7 +318,7 @@ class Sql2ToQomQueryConverter
      */
     protected function parseChildNodeJoinCondition()
     {
-        $this->scanner->expectTokens(array('ISCHILDNODE', '('));
+        $this->scanner->expectTokens(['ISCHILDNODE', '(']);
         $child = $this->fetchTokenWithoutBrackets();
         $this->scanner->expectToken(',');
         $parent = $this->fetchTokenWithoutBrackets();
@@ -532,7 +533,7 @@ class Sql2ToQomQueryConverter
             return $this->factory->notConstraint($this->factory->propertyExistence($selectorName, $prop));
         }
 
-        $this->scanner->expectTokens(array('NOT', 'NULL'));
+        $this->scanner->expectTokens(['NOT', 'NULL']);
 
         return $this->factory->propertyExistence($selectorName, $prop);
     }
@@ -544,7 +545,7 @@ class Sql2ToQomQueryConverter
      */
     protected function parseFullTextSearch()
     {
-        $this->scanner->expectTokens(array('CONTAINS', '('));
+        $this->scanner->expectTokens(['CONTAINS', '(']);
 
         list($selectorName, $propertyName) = $this->parseIdentifier();
         $this->scanner->expectToken(',');
@@ -559,7 +560,7 @@ class Sql2ToQomQueryConverter
      */
     protected function parseSameNode()
     {
-        $this->scanner->expectTokens(array('ISSAMENODE', '('));
+        $this->scanner->expectTokens(['ISSAMENODE', '(']);
         if ($this->scanner->tokenIs($this->scanner->lookupNextToken(1), ',')) {
             $selectorName = $this->scanner->fetchNextToken();
             $this->scanner->expectToken(',');
@@ -578,7 +579,7 @@ class Sql2ToQomQueryConverter
      */
     protected function parseChildNode()
     {
-        $this->scanner->expectTokens(array('ISCHILDNODE', '('));
+        $this->scanner->expectTokens(['ISCHILDNODE', '(']);
         if ($this->scanner->tokenIs($this->scanner->lookupNextToken(1), ',')) {
             $selectorName = $this->scanner->fetchNextToken();
             $this->scanner->expectToken(',');
@@ -597,7 +598,7 @@ class Sql2ToQomQueryConverter
      */
     protected function parseDescendantNode()
     {
-        $this->scanner->expectTokens(array('ISDESCENDANTNODE', '('));
+        $this->scanner->expectTokens(['ISDESCENDANTNODE', '(']);
         if ($this->scanner->tokenIs($this->scanner->lookupNextToken(1), ',')) {
             $selectorName = $this->scanner->fetchNextToken();
             $this->scanner->expectToken(',');
@@ -856,8 +857,9 @@ class Sql2ToQomQueryConverter
      */
     protected function parseOrderings()
     {
-        $orderings = array();
+        $orderings = [];
         $continue = true;
+
         while ($continue) {
             $orderings[] = $this->parseOrdering();
             if ($this->scanner->tokenIs($this->scanner->lookupNextToken(), ',')) {
@@ -911,10 +913,10 @@ class Sql2ToQomQueryConverter
         if ($this->scanner->lookupNextToken() === '*') {
             $this->scanner->fetchNextToken();
 
-            return array();
+            return [];
         }
 
-        $columns = array();
+        $columns = [];
         $hasNext = true;
 
         while ($hasNext) {
@@ -940,7 +942,7 @@ class Sql2ToQomQueryConverter
      */
     protected function buildColumns($data)
     {
-        $columns = array();
+        $columns = [];
         foreach ($data as $col) {
             $columns[] = $this->buildColumn($col);
         }

--- a/src/PHPCR/Util/TraversingItemVisitor.php
+++ b/src/PHPCR/Util/TraversingItemVisitor.php
@@ -153,7 +153,7 @@ abstract class TraversingItemVisitor implements ItemVisitorInterface
      */
     public function visit(ItemInterface $item)
     {
-        if ($this->currentDepth == 0) {
+        if ($this->currentDepth === 0) {
             $this->currentDepth = $item->getDepth();
         }
         if ($item instanceof PropertyInterface) {

--- a/src/PHPCR/Util/TreeWalker.php
+++ b/src/PHPCR/Util/TreeWalker.php
@@ -35,14 +35,14 @@ class TreeWalker
      *
      * @var TreeWalkerFilterInterface[]
      */
-    protected $nodeFilters = array();
+    protected $nodeFilters = [];
 
     /**
      * Filters to apply to decide whether a property needs to be visited
      *
      * @var TreeWalkerFilterInterface[]
      */
-    protected $propertyFilters = array();
+    protected $propertyFilters = [];
 
     /**
      * Instantiate a tree walker

--- a/src/PHPCR/Util/UUIDHelper.php
+++ b/src/PHPCR/Util/UUIDHelper.php
@@ -41,7 +41,7 @@ class UUIDHelper
      */
     public static function generateUUID()
     {
-        if (class_exists('Ramsey\Uuid\Uuid')) {
+        if (class_exists(Uuid::class)) {
             $uuid4 = Uuid::uuid4();
 
             return $uuid4->toString();

--- a/tests/PHPCR/Tests/Stubs/MockNode.php
+++ b/tests/PHPCR/Tests/Stubs/MockNode.php
@@ -2,8 +2,9 @@
 
 namespace PHPCR\Tests\Stubs;
 
+use Iterator;
 use PHPCR\NodeInterface;
 
-abstract class MockNode implements \Iterator, NodeInterface
+abstract class MockNode implements Iterator, NodeInterface
 {
 }

--- a/tests/PHPCR/Tests/Stubs/MockNodeTypeManager.php
+++ b/tests/PHPCR/Tests/Stubs/MockNodeTypeManager.php
@@ -2,8 +2,9 @@
 
 namespace PHPCR\Tests\Stubs;
 
+use Iterator;
 use PHPCR\NodeType\NodeTypeManagerInterface;
 
-abstract class MockNodeTypeManager implements \Iterator, NodeTypeManagerInterface
+abstract class MockNodeTypeManager implements Iterator, NodeTypeManagerInterface
 {
 }

--- a/tests/PHPCR/Tests/Stubs/MockRow.php
+++ b/tests/PHPCR/Tests/Stubs/MockRow.php
@@ -2,8 +2,9 @@
 
 namespace PHPCR\Tests\Stubs;
 
+use Iterator;
 use PHPCR\Query\RowInterface;
 
-abstract class MockRow implements \Iterator, RowInterface
+abstract class MockRow implements Iterator, RowInterface
 {
 }

--- a/tests/PHPCR/Tests/Util/CND/Reader/BufferReaderTest.php
+++ b/tests/PHPCR/Tests/Util/CND/Reader/BufferReaderTest.php
@@ -3,15 +3,16 @@
 namespace PHPCR\Tests\Util\CND\Reader;
 
 use PHPCR\Util\CND\Reader\BufferReader;
+use PHPUnit_Framework_TestCase;
 
-class BufferReaderTest extends \PHPUnit_Framework_TestCase
+class BufferReaderTest extends PHPUnit_Framework_TestCase
 {
     public function test__construct()
     {
         $buffer = "Some random\nor\r\nstring";
         $reader = new BufferReader($buffer);
 
-        $this->assertInstanceOf('\PHPCR\Util\CND\Reader\BufferReader', $reader);
+        $this->assertInstanceOf(BufferReader::class, $reader);
         $this->assertAttributeEquals(str_replace("\r\n", "\n", $buffer) . $reader->getEofMarker(), 'buffer', $reader);
         $this->assertAttributeEquals(0, 'startPos', $reader);
         $this->assertAttributeEquals(0, 'forwardPos', $reader);
@@ -89,7 +90,7 @@ class BufferReaderTest extends \PHPUnit_Framework_TestCase
     {
         $reader = new BufferReader('');
 
-        $this->assertInstanceOf('\PHPCR\Util\CND\Reader\BufferReader', $reader);
+        $this->assertInstanceOf(BufferReader::class, $reader);
         $this->assertAttributeEquals($reader->getEofMarker(), 'buffer', $reader);
         $this->assertAttributeEquals(0, 'startPos', $reader);
         $this->assertAttributeEquals(0, 'forwardPos', $reader);

--- a/tests/PHPCR/Tests/Util/CND/Reader/FileReaderTest.php
+++ b/tests/PHPCR/Tests/Util/CND/Reader/FileReaderTest.php
@@ -2,36 +2,52 @@
 
 namespace PHPCR\Tests\Util\CND\Reader;
 
+use InvalidArgumentException;
 use PHPCR\Util\CND\Reader\FileReader;
+use PHPUnit_Framework_TestCase;
 
-class FileReaderTest extends \PHPUnit_Framework_TestCase
+class FileReaderTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @var string
+     */
+    private $filepath;
+
+    /**
+     * @var FileReader
+     */
+    private $reader;
+
+    /**
+     * @var array
+     */
+    private $lines;
+
     public function setUp()
     {
         $this->filepath = __DIR__ . '/../Fixtures/files/TestFile.txt';
         $this->reader = new FileReader($this->filepath);
 
-        $this->lines = array(
+        $this->lines = [
             'This is a test file...',
             '',
             '...containing dummy content.',
             ''
-        );
+        ];
 
         $this->chars = array_merge(
             preg_split('//', $this->lines[0], -1, PREG_SPLIT_NO_EMPTY),
-            array("\n", "\n"),
+            ["\n", "\n"],
             preg_split('//', $this->lines[2], -1, PREG_SPLIT_NO_EMPTY),
-            array("\n", "\n")
+            ["\n", "\n"]
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function test__construct_fileNotFound()
     {
-        $reader = new FileReader('unexisting_file');
+        $this->expectException(InvalidArgumentException::class);
+
+        new FileReader('unexisting_file');
     }
 
     public function testGetPath()

--- a/tests/PHPCR/Tests/Util/CND/Scanner/GenericScannerTest.php
+++ b/tests/PHPCR/Tests/Util/CND/Scanner/GenericScannerTest.php
@@ -2,111 +2,115 @@
 
 namespace PHPCR\Tests\Util\CND\Scanner;
 
+use ArrayIterator;
 use PHPCR\Util\CND\Scanner\GenericScanner;
 use PHPCR\Util\CND\Reader\FileReader;
 use PHPCR\Util\CND\Scanner\GenericToken as Token;
 use PHPCR\Util\CND\Scanner\TokenQueue;
 use PHPCR\Util\CND\Scanner\TokenFilter;
 use PHPCR\Util\CND\Scanner\Context\DefaultScannerContext;
+use PHPUnit_Framework_TestCase;
+use Test;
+use TestClass;
 
-class GenericScannerTest extends \PHPUnit_Framework_TestCase
+class GenericScannerTest extends PHPUnit_Framework_TestCase
 {
-    protected $expectedTokens = array(
+    protected $expectedTokens = [
 
         // <opening php tag>
-        array(Token::TK_SYMBOL, '<'),
-        array(Token::TK_SYMBOL, '?'),
-        array(Token::TK_IDENTIFIER, 'php'),
-        array(Token::TK_NEWLINE, ''),
-        array(Token::TK_NEWLINE, ''),
+        [Token::TK_SYMBOL, '<'],
+        [Token::TK_SYMBOL, '?'],
+        [Token::TK_IDENTIFIER, 'php'],
+        [Token::TK_NEWLINE, ''],
+        [Token::TK_NEWLINE, ''],
 
         // namespace Test\Foobar;
-        array(Token::TK_IDENTIFIER, 'namespace'),
-        array(Token::TK_WHITESPACE, ''),
-        array(Token::TK_IDENTIFIER, 'Test'),
-        array(Token::TK_SYMBOL, '\\'),
-        array(Token::TK_IDENTIFIER, 'Foobar'),
-        array(Token::TK_SYMBOL, ';'),
-        array(Token::TK_NEWLINE, ''),
-        array(Token::TK_NEWLINE, ''),
+        [Token::TK_IDENTIFIER, 'namespace'],
+        [Token::TK_WHITESPACE, ''],
+        [Token::TK_IDENTIFIER, Test::class],
+        [Token::TK_SYMBOL, '\\'],
+        [Token::TK_IDENTIFIER, 'Foobar'],
+        [Token::TK_SYMBOL, ';'],
+        [Token::TK_NEWLINE, ''],
+        [Token::TK_NEWLINE, ''],
 
         // class TestClass {
-        array(Token::TK_IDENTIFIER, 'class'),
-        array(Token::TK_WHITESPACE, ''),
-        array(Token::TK_IDENTIFIER, 'TestClass'),
-        array(Token::TK_NEWLINE, ''),
-        array(Token::TK_SYMBOL, '{'),
-        array(Token::TK_NEWLINE, ''),
+        [Token::TK_IDENTIFIER, 'class'],
+        [Token::TK_WHITESPACE, ''],
+        [Token::TK_IDENTIFIER, TestClass::class],
+        [Token::TK_NEWLINE, ''],
+        [Token::TK_SYMBOL, '{'],
+        [Token::TK_NEWLINE, ''],
 
         // /** ... */
-        array(Token::TK_WHITESPACE, ''),
-        array(Token::TK_COMMENT, "/**\n     * Block comment\n     */"),
-        array(Token::TK_NEWLINE, ''),
+        [Token::TK_WHITESPACE, ''],
+        [Token::TK_COMMENT, "/**\n     * Block comment\n     */"],
+        [Token::TK_NEWLINE, ''],
 
         // public function testMethod($testParam) {
-        array(Token::TK_WHITESPACE, ''),
-        array(Token::TK_IDENTIFIER, 'public'),
-        array(Token::TK_WHITESPACE, ''),
-        array(Token::TK_IDENTIFIER, 'function'),
-        array(Token::TK_WHITESPACE, ''),
-        array(Token::TK_IDENTIFIER, 'testMethod'),
-        array(Token::TK_SYMBOL, '('),
-        array(Token::TK_SYMBOL, '$'),
-        array(Token::TK_IDENTIFIER, 'testParam'),
-        array(Token::TK_SYMBOL, ')'),
-        array(Token::TK_NEWLINE, ''),
-        array(Token::TK_WHITESPACE, ''),
-        array(Token::TK_SYMBOL, '{'),
-        array(Token::TK_NEWLINE, ''),
+        [Token::TK_WHITESPACE, ''],
+        [Token::TK_IDENTIFIER, 'public'],
+        [Token::TK_WHITESPACE, ''],
+        [Token::TK_IDENTIFIER, 'function'],
+        [Token::TK_WHITESPACE, ''],
+        [Token::TK_IDENTIFIER, 'testMethod'],
+        [Token::TK_SYMBOL, '('],
+        [Token::TK_SYMBOL, '$'],
+        [Token::TK_IDENTIFIER, 'testParam'],
+        [Token::TK_SYMBOL, ')'],
+        [Token::TK_NEWLINE, ''],
+        [Token::TK_WHITESPACE, ''],
+        [Token::TK_SYMBOL, '{'],
+        [Token::TK_NEWLINE, ''],
 
         // // Line comment
-        array(Token::TK_WHITESPACE, ''),
-        array(Token::TK_COMMENT, '// Line comment'),
-        array(Token::TK_NEWLINE, ''),
+        [Token::TK_WHITESPACE, ''],
+        [Token::TK_COMMENT, '// Line comment'],
+        [Token::TK_NEWLINE, ''],
 
         // $string = 'This is a "Test // string"';
-        array(Token::TK_WHITESPACE, ''),
-        array(Token::TK_SYMBOL, '$'),
-        array(Token::TK_IDENTIFIER, 'string'),
-        array(Token::TK_WHITESPACE, ''),
-        array(Token::TK_SYMBOL, '='),
-        array(Token::TK_WHITESPACE, ''),
-        array(Token::TK_STRING, '\'This is a "Test // string"\''),
-        array(Token::TK_SYMBOL, ';'),
-        array(Token::TK_NEWLINE, ''),
+        [Token::TK_WHITESPACE, ''],
+        [Token::TK_SYMBOL, '$'],
+        [Token::TK_IDENTIFIER, 'string'],
+        [Token::TK_WHITESPACE, ''],
+        [Token::TK_SYMBOL, '='],
+        [Token::TK_WHITESPACE, ''],
+        [Token::TK_STRING, '\'This is a "Test // string"\''],
+        [Token::TK_SYMBOL, ';'],
+        [Token::TK_NEWLINE, ''],
 
         // empty line before return
-        array(Token::TK_NEWLINE, ''),
+        [Token::TK_NEWLINE, ''],
 
         // return "Test string";
-        array(Token::TK_WHITESPACE, ''),
-        array(Token::TK_IDENTIFIER, 'return'),
-        array(Token::TK_WHITESPACE, ''),
-        array(Token::TK_STRING, '"Test string"'),
-        array(Token::TK_SYMBOL, ';'),
-        array(Token::TK_NEWLINE, ''),
+        [Token::TK_WHITESPACE, ''],
+        [Token::TK_IDENTIFIER, 'return'],
+        [Token::TK_WHITESPACE, ''],
+        [Token::TK_STRING, '"Test string"'],
+        [Token::TK_SYMBOL, ';'],
+        [Token::TK_NEWLINE, ''],
 
         // }
-        array(Token::TK_WHITESPACE, ''),
-        array(Token::TK_SYMBOL, '}'),
-        array(Token::TK_NEWLINE, ''),
-        array(Token::TK_NEWLINE, ''),
+        [Token::TK_WHITESPACE, ''],
+        [Token::TK_SYMBOL, '}'],
+        [Token::TK_NEWLINE, ''],
+        [Token::TK_NEWLINE, ''],
 
         // // String in "comment"
-        array(Token::TK_WHITESPACE, ''),
-        array(Token::TK_COMMENT, '// String in "comment"'),
-        array(Token::TK_NEWLINE, ''),
+        [Token::TK_WHITESPACE, ''],
+        [Token::TK_COMMENT, '// String in "comment"'],
+        [Token::TK_NEWLINE, ''],
 
         // }
-        array(Token::TK_SYMBOL, '}'),
-        array(Token::TK_NEWLINE, ''),
-    );
+        [Token::TK_SYMBOL, '}'],
+        [Token::TK_NEWLINE, ''],
+    ];
 
     protected $expectedTokensNoEmptyToken;
 
     public function setUp()
     {
-        $this->expectedTokensNoEmptyToken = array();
+        $this->expectedTokensNoEmptyToken = [];
         foreach ($this->expectedTokens as $token) {
             if ($token[0] !== Token::TK_NEWLINE && $token[0] !== Token::TK_WHITESPACE) {
                 $this->expectedTokensNoEmptyToken[] = $token;
@@ -142,7 +146,7 @@ class GenericScannerTest extends \PHPUnit_Framework_TestCase
     {
         $queue->reset();
 
-        $it = new \ArrayIterator($tokens);
+        $it = new ArrayIterator($tokens);
 
         $token = $queue->peek();
 

--- a/tests/PHPCR/Tests/Util/CND/Scanner/TokenQueueTest.php
+++ b/tests/PHPCR/Tests/Util/CND/Scanner/TokenQueueTest.php
@@ -4,9 +4,35 @@ namespace PHPCR\Tests\Util\CND\Scanner;
 
 use PHPCR\Util\CND\Scanner\Token;
 use PHPCR\Util\CND\Scanner\TokenQueue;
+use PHPUnit_Framework_TestCase;
 
-class TokenQueueTest extends \PHPUnit_Framework_TestCase
+class TokenQueueTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @var Token
+     */
+    private $token0;
+
+    /**
+     * @var Token
+     */
+    private $token1;
+
+    /**
+     * @var Token
+     */
+    private $token2;
+
+    /**
+     * @var Token
+     */
+    private $token3;
+
+    /**
+     * @var TokenQueue
+     */
+    private $queue;
+
     public function setUp()
     {
         $this->token0 = new Token(0, 'token 0');
@@ -24,13 +50,13 @@ class TokenQueueTest extends \PHPUnit_Framework_TestCase
     public function testAdd()
     {
         $queue = new TokenQueue();
-        $this->assertAttributeEquals(array(), 'tokens', $queue);
+        $this->assertAttributeEquals([], 'tokens', $queue);
 
         $queue->add($this->token0);
-        $this->assertAttributeEquals(array($this->token0), 'tokens', $queue);
+        $this->assertAttributeEquals([$this->token0], 'tokens', $queue);
 
         $queue->add($this->token1);
-        $this->assertAttributeEquals(array($this->token0, $this->token1), 'tokens', $queue);
+        $this->assertAttributeEquals([$this->token0, $this->token1], 'tokens', $queue);
     }
 
     public function testResetAndPeek()

--- a/tests/PHPCR/Tests/Util/CND/Scanner/TokenTest.php
+++ b/tests/PHPCR/Tests/Util/CND/Scanner/TokenTest.php
@@ -3,9 +3,15 @@
 namespace PHPCR\Tests\Util\CND\Scanner;
 
 use PHPCR\Util\CND\Scanner\Token;
+use PHPUnit_Framework_TestCase;
 
-class TokenTest extends \PHPUnit_Framework_TestCase
+class TokenTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @var Token
+     */
+    private $token;
+
     public function setUp()
     {
         $this->token = new Token(123, 'foobar');

--- a/tests/PHPCR/Tests/Util/Console/Command/BaseCommandTest.php
+++ b/tests/PHPCR/Tests/Util/Console/Command/BaseCommandTest.php
@@ -6,6 +6,10 @@ use PHPCR\NodeInterface;
 use PHPCR\Query\QueryManagerInterface;
 use PHPCR\Query\RowInterface;
 use PHPCR\RepositoryInterface;
+use PHPCR\Tests\Stubs\MockNode;
+use PHPCR\Tests\Stubs\MockRow;
+use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit_Framework_TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Console\Helper\HelperSet;
@@ -14,44 +18,44 @@ use PHPCR\WorkspaceInterface;
 use PHPCR\Util\Console\Helper\PhpcrConsoleDumperHelper;
 use PHPCR\Util\Console\Helper\PhpcrHelper;
 
-require_once(__DIR__.'/../../../Stubs/MockNode.php');
-require_once(__DIR__.'/../../../Stubs/MockNodeTypeManager.php');
-require_once(__DIR__.'/../../../Stubs/MockRow.php');
+require_once __DIR__.'/../../../Stubs/MockNode.php';
+require_once __DIR__.'/../../../Stubs/MockNodeTypeManager.php';
+require_once __DIR__.'/../../../Stubs/MockRow.php';
 
-abstract class BaseCommandTest extends \PHPUnit_Framework_TestCase
+abstract class BaseCommandTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var SessionInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var SessionInterface|PHPUnit_Framework_MockObject_MockObject
      * */
     public $session;
 
     /**
-     * @var WorkspaceInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var WorkspaceInterface|PHPUnit_Framework_MockObject_MockObject
      */
     public $workspace;
 
     /**
-     * @var RepositoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var RepositoryInterface|PHPUnit_Framework_MockObject_MockObject
      */
     public $repository;
 
     /**
-     * @var PhpcrConsoleDumperHelper|\PHPUnit_Framework_MockObject_MockObject
+     * @var PhpcrConsoleDumperHelper|PHPUnit_Framework_MockObject_MockObject
      */
     public $dumperHelper;
 
     /**
-     * @var NodeInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var NodeInterface|PHPUnit_Framework_MockObject_MockObject
      */
     public $node1;
 
     /**
-     * @var RowInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var RowInterface|PHPUnit_Framework_MockObject_MockObject
      */
     public $row1;
 
     /**
-     * @var QueryManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var QueryManagerInterface|PHPUnit_Framework_MockObject_MockObject
      */
     public $queryManager;
 
@@ -67,38 +71,43 @@ abstract class BaseCommandTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->session = $this->getMock('PHPCR\SessionInterface');
-        $this->workspace = $this->getMock('PHPCR\WorkspaceInterface');
-        $this->repository = $this->getMock('PHPCR\RepositoryInterface');
-        $this->queryManager = $this->getMock('PHPCR\Query\QueryManagerInterface');
+        $this->session = $this->createMock(SessionInterface::class);
+        $this->workspace = $this->createMock(WorkspaceInterface::class);
+        $this->repository = $this->createMock(RepositoryInterface::class);
+        $this->queryManager = $this->createMock(QueryManagerInterface::class);
 
-        $this->row1 = $this->getMock('PHPCR\Tests\Stubs\MockRow');
-        $this->node1 = $this->getMock('PHPCR\Tests\Stubs\MockNode');
+        $this->row1 = $this->createMock(MockRow::class);
+        $this->node1 = $this->createMock(MockNode::class);
 
-        $this->dumperHelper = $this->getMockBuilder(
-            'PHPCR\Util\Console\Helper\PhpcrConsoleDumperHelper'
-        )->disableOriginalConstructor()->getMock();
+        $this->dumperHelper = $this->getMockBuilder(PhpcrConsoleDumperHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
 
-        $this->helperSet = new HelperSet(array(
+        $this->helperSet = new HelperSet([
             'phpcr' => new PhpcrHelper($this->session),
             'phpcr_console_dumper' => $this->dumperHelper,
-        ));
+        ]);
 
         $this->session->expects($this->any())
             ->method('getWorkspace')
-            ->will($this->returnValue($this->workspace));
+            ->will($this->returnValue($this->workspace))
+        ;
 
         $this->workspace->expects($this->any())
             ->method('getName')
-            ->will($this->returnValue('test'));
+            ->will($this->returnValue('test'))
+        ;
 
         $this->workspace->expects($this->any())
             ->method('getQueryManager')
-            ->will($this->returnValue($this->queryManager));
+            ->will($this->returnValue($this->queryManager))
+        ;
 
         $this->queryManager->expects($this->any())
             ->method('getSupportedQueryLanguages')
-            ->will($this->returnValue(array('JCR-SQL2')));
+            ->will($this->returnValue(['JCR-SQL2']))
+        ;
 
         $this->application = new Application();
         $this->application->setHelperSet($this->helperSet);
@@ -117,9 +126,7 @@ abstract class BaseCommandTest extends \PHPUnit_Framework_TestCase
     {
         $command = $this->application->find($name);
         $commandTester = new CommandTester($command);
-        $args = array_merge(array(
-            'command' => $command->getName(),
-        ), $args);
+        $args = array_merge(['command' => $command->getName()], $args);
         $this->assertEquals($status, $commandTester->execute($args));
 
         return $commandTester;

--- a/tests/PHPCR/Tests/Util/Console/Command/NodeDumpCommandTest.php
+++ b/tests/PHPCR/Tests/Util/Console/Command/NodeDumpCommandTest.php
@@ -2,9 +2,9 @@
 
 namespace PHPCR\Tests\Util\Console\Command;
 
+use Exception;
 use PHPCR\ItemNotFoundException;
 use PHPCR\Util\UUIDHelper;
-use Symfony\Component\Console\Application;
 use PHPCR\Util\TreeWalker;
 use PHPCR\Util\Console\Command\NodeDumpCommand;
 
@@ -16,9 +16,10 @@ class NodeDumpCommandTest extends BaseCommandTest
     public function setUp()
     {
         parent::setUp();
-        $this->treeWalker = $this->getMockBuilder(
-            'PHPCR\Util\TreeWalker'
-        )->disableOriginalConstructor()->getMock();
+        $this->treeWalker = $this->getMockBuilder(TreeWalker::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
 
         $ndCommand = new NodeDumpCommand();
         $this->application->add($ndCommand);
@@ -31,12 +32,14 @@ class NodeDumpCommandTest extends BaseCommandTest
             ->method('getTreeWalker')
             ->will($this->returnValue($this->treeWalker))
         ;
+
         $this->session
             ->expects($this->once())
             ->method('getNode')
             ->with('/')
             ->will($this->returnValue($this->node1))
         ;
+
         $this->treeWalker
             ->expects($this->once())
             ->method('traverse')
@@ -55,27 +58,28 @@ class NodeDumpCommandTest extends BaseCommandTest
             ->method('getTreeWalker')
             ->will($this->returnValue($this->treeWalker))
         ;
+
         $this->session
             ->expects($this->once())
             ->method('getNodeByIdentifier')
             ->with($uuid)
             ->will($this->returnValue($this->node1))
         ;
+
         $this->treeWalker
             ->expects($this->once())
             ->method('traverse')
             ->with($this->node1)
         ;
 
-        $this->executeCommand('phpcr:node:dump', array('identifier' => $uuid));
+        $this->executeCommand('phpcr:node:dump', ['identifier' => $uuid]);
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function testInvalidRefFormat()
     {
-        $this->executeCommand('phpcr:node:dump', array('--ref-format' => 'xy'));
+        $this->expectException(Exception::class);
+
+        $this->executeCommand('phpcr:node:dump', ['--ref-format' => 'xy']);
         $this->fail('invalid ref-format did not produce exception');
     }
 
@@ -88,7 +92,7 @@ class NodeDumpCommandTest extends BaseCommandTest
             ->will($this->throwException(new ItemNotFoundException()))
         ;
 
-        $ct = $this->executeCommand('phpcr:node:dump', array(), 1);
+        $ct = $this->executeCommand('phpcr:node:dump', [], 1);
         $this->assertContains('does not exist', $ct->getDisplay());
     }
 }

--- a/tests/PHPCR/Tests/Util/Console/Command/NodeMoveCommandTest.php
+++ b/tests/PHPCR/Tests/Util/Console/Command/NodeMoveCommandTest.php
@@ -2,16 +2,13 @@
 
 namespace PHPCR\Tests\Util\Console\Command;
 
-use Symfony\Component\Console\Application;
 use PHPCR\Util\Console\Command\NodeMoveCommand;
 
 class NodeMoveCommandTest extends BaseCommandTest
 {
     public function provideCommand()
     {
-        return array(
-            array(array('source' => '/foo', 'destination' => '/bar'))
-        );
+        return [[['source' => '/foo', 'destination' => '/bar']]];
     }
 
     /**
@@ -21,9 +18,12 @@ class NodeMoveCommandTest extends BaseCommandTest
     {
         $this->session->expects($this->once())
             ->method('move')
-            ->with($args['source'], $args['destination']);
+            ->with($args['source'], $args['destination'])
+        ;
+
         $this->session->expects($this->once())
-            ->method('save');
+            ->method('save')
+        ;
 
         $this->application->add(new NodeMoveCommand());
         $this->executeCommand('phpcr:node:move', $args);

--- a/tests/PHPCR/Tests/Util/Console/Command/NodeRemoveCommandTest.php
+++ b/tests/PHPCR/Tests/Util/Console/Command/NodeRemoveCommandTest.php
@@ -2,7 +2,7 @@
 
 namespace PHPCR\Tests\Util\Console\Command;
 
-use Symfony\Component\Console\Application;
+use LogicException;
 use PHPCR\Util\Console\Command\NodeRemoveCommand;
 
 class NodeRemoveCommandTest extends BaseCommandTest
@@ -10,6 +10,7 @@ class NodeRemoveCommandTest extends BaseCommandTest
     public function setUp()
     {
         parent::setUp();
+
         $this->application->add(new NodeRemoveCommand());
     }
 
@@ -19,18 +20,17 @@ class NodeRemoveCommandTest extends BaseCommandTest
             ->method('removeItem')
             ->with('/cms');
 
-        $ct = $this->executeCommand('phpcr:node:remove', array(
+        $this->executeCommand('phpcr:node:remove', array(
             '--force' => true,
             'path' => '/cms',
         ));
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testRemoveRoot()
     {
-        $ct = $this->executeCommand('phpcr:node:remove', array(
+        $this->expectException(LogicException::class);
+
+        $this->executeCommand('phpcr:node:remove', array(
             '--force' => true,
             'path' => '/',
         ));

--- a/tests/PHPCR/Tests/Util/Console/Command/NodeTypeListCommandTest.php
+++ b/tests/PHPCR/Tests/Util/Console/Command/NodeTypeListCommandTest.php
@@ -2,32 +2,45 @@
 
 namespace PHPCR\Tests\Util\Console\Command;
 
-use Symfony\Component\Console\Application;
+use PHPCR\Tests\Stubs\MockNodeTypeManager;
 use PHPCR\Util\Console\Command\NodeTypeListCommand;
+use PHPUnit_Framework_MockObject_MockObject;
 
 class NodeTypeListCommandTest extends BaseCommandTest
 {
+    /**
+     * @var MockNodeTypeManager|PHPUnit_Framework_MockObject_MockObject
+     */
+    private $nodeTypeManager;
+
     public function setUp()
     {
         parent::setUp();
+
         $this->application->add(new NodeTypeListCommand());
-        $this->nodeTypeManager = $this->getMockBuilder(
-            'PHPCR\Tests\Stubs\MockNodeTypeManager'
-        )->disableOriginalConstructor()->getMock();
+        $this->nodeTypeManager = $this->getMockBuilder(MockNodeTypeManager::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
     }
 
     public function testNodeTypeList()
     {
         $this->session->expects($this->once())
             ->method('getWorkspace')
-            ->will($this->returnValue($this->workspace));
+            ->will($this->returnValue($this->workspace))
+        ;
+
         $this->workspace->expects($this->once())
             ->method('getNodeTypeManager')
-            ->will($this->returnValue($this->nodeTypeManager));
+            ->will($this->returnValue($this->nodeTypeManager))
+        ;
+
         $this->nodeTypeManager->expects($this->once())
             ->method('getAllNodeTypes')
-            ->will($this->returnValue(array()));
-        $ct = $this->executeCommand('phpcr:node-type:list', array(
-        ));
+            ->will($this->returnValue([]))
+        ;
+
+        $this->executeCommand('phpcr:node-type:list', []);
     }
 }

--- a/tests/PHPCR/Tests/Util/Console/Command/NodeTypeRegisterCommandTest.php
+++ b/tests/PHPCR/Tests/Util/Console/Command/NodeTypeRegisterCommandTest.php
@@ -2,33 +2,45 @@
 
 namespace PHPCR\Tests\Util\Console\Command;
 
-use Symfony\Component\Console\Application;
+use PHPCR\Tests\Stubs\MockNodeTypeManager;
 use PHPCR\Util\Console\Command\NodeTypeRegisterCommand;
+use PHPUnit_Framework_MockObject_MockObject;
 
 class NodeTypeRegisterCommandTest extends BaseCommandTest
 {
+    /**
+     * @var MockNodeTypeManager|PHPUnit_Framework_MockObject_MockObject
+     */
+    private $nodeTypeManager;
+
     public function setUp()
     {
         parent::setUp();
+
         $this->application->add(new NodeTypeRegisterCommand());
-        $this->nodeTypeManager = $this->getMockBuilder(
-            'PHPCR\Tests\Stubs\MockNodeTypeManager'
-        )->disableOriginalConstructor()->getMock();
+        $this->nodeTypeManager = $this->getMockBuilder(MockNodeTypeManager::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
     }
 
     public function testNodeTypeRegister()
     {
         $this->session->expects($this->once())
             ->method('getWorkspace')
-            ->will($this->returnValue($this->workspace));
+            ->will($this->returnValue($this->workspace))
+        ;
+
         $this->workspace->expects($this->once())
             ->method('getNodeTypeManager')
-            ->will($this->returnValue($this->nodeTypeManager));
+            ->will($this->returnValue($this->nodeTypeManager))
+        ;
+
         $this->nodeTypeManager->expects($this->once())
             ->method('registerNodeTypesCnd');
 
-        $ct = $this->executeCommand('phpcr:node-type:register', array(
-    'cnd-file' => array(__DIR__.'/fixtures/cnd_dummy.cnd'),
-        ));
+        $this->executeCommand('phpcr:node-type:register', [
+            'cnd-file' => [__DIR__.'/fixtures/cnd_dummy.cnd'],
+        ]);
     }
 }

--- a/tests/PHPCR/Tests/Util/Console/Command/WorkspaceCreateCommandTest.php
+++ b/tests/PHPCR/Tests/Util/Console/Command/WorkspaceCreateCommandTest.php
@@ -2,8 +2,6 @@
 
 namespace PHPCR\Tests\Util\Console\Command;
 
-use PHPCR\RepositoryException;
-use Symfony\Component\Console\Application;
 use PHPCR\Util\Console\Command\WorkspaceCreateCommand;
 use PHPCR\RepositoryInterface;
 
@@ -12,6 +10,7 @@ class WorkspaceCreateCommandTest extends BaseCommandTest
     public function setUp()
     {
         parent::setUp();
+
         $this->application->add(new WorkspaceCreateCommand());
     }
 
@@ -21,27 +20,31 @@ class WorkspaceCreateCommandTest extends BaseCommandTest
             ->method('getWorkspace')
             ->will($this->returnValue($this->workspace))
         ;
+
         $this->session->expects($this->once())
             ->method('getRepository')
             ->will($this->returnValue($this->repository))
         ;
+
         $this->repository->expects($this->once())
             ->method('getDescriptor')
             ->with(RepositoryInterface::OPTION_WORKSPACE_MANAGEMENT_SUPPORTED)
             ->will($this->returnValue(true))
         ;
+
         $this->workspace->expects($this->once())
             ->method('createWorkspace')
             ->with('test_workspace')
         ;
+
         $this->workspace->expects($this->once())
             ->method('getAccessibleWorkspaceNames')
-            ->will($this->returnValue(array('default')))
+            ->will($this->returnValue(['default']))
         ;
 
-        $this->executeCommand('phpcr:workspace:create', array(
+        $this->executeCommand('phpcr:workspace:create', [
             'name' => 'test_workspace'
-        ));
+        ]);
     }
 
     /**
@@ -53,22 +56,26 @@ class WorkspaceCreateCommandTest extends BaseCommandTest
             ->method('getWorkspace')
             ->will($this->returnValue($this->workspace))
         ;
+
         $this->session->expects($this->exactly(2))
             ->method('getRepository')
-            ->will($this->returnValue($this->repository));
+            ->will($this->returnValue($this->repository))
+        ;
+
         $this->repository->expects($this->exactly(2))
             ->method('getDescriptor')
             ->with(RepositoryInterface::OPTION_WORKSPACE_MANAGEMENT_SUPPORTED)
             ->will($this->returnValue(true))
         ;
+
         $this->workspace->expects($this->exactly(2))
             ->method('getAccessibleWorkspaceNames')
-            ->will($this->returnValue(array('default', 'test')))
+            ->will($this->returnValue(['default', 'test']))
         ;
 
         $tester = $this->executeCommand(
             'phpcr:workspace:create',
-            array('name' => 'test'),
+            ['name' => 'test'],
             2
         );
 
@@ -76,10 +83,10 @@ class WorkspaceCreateCommandTest extends BaseCommandTest
 
         $tester = $this->executeCommand(
             'phpcr:workspace:create',
-            array(
+            [
                 'name' => 'test',
                 '--ignore-existing' => true
-            ),
+            ],
             0
         );
 

--- a/tests/PHPCR/Tests/Util/Console/Command/WorkspaceDeleteCommandTest.php
+++ b/tests/PHPCR/Tests/Util/Console/Command/WorkspaceDeleteCommandTest.php
@@ -2,7 +2,6 @@
 
 namespace PHPCR\Tests\Util\Console\Command;
 
-use Symfony\Component\Console\Application;
 use PHPCR\Util\Console\Command\WorkspaceDeleteCommand;
 use PHPCR\RepositoryInterface;
 
@@ -11,6 +10,7 @@ class WorkspaceDeleteCommandTest extends BaseCommandTest
     public function setUp()
     {
         parent::setUp();
+
         $this->application->add(new WorkspaceDeleteCommand());
     }
 
@@ -20,19 +20,23 @@ class WorkspaceDeleteCommandTest extends BaseCommandTest
             ->method('getWorkspace')
             ->will($this->returnValue($this->workspace))
         ;
+
         $this->workspace->expects($this->once())
             ->method('getAccessibleWorkspaceNames')
-            ->will($this->returnValue(array('default', 'test_workspace', 'other')))
+            ->will($this->returnValue(['default', 'test_workspace', 'other']))
         ;
+
         $this->session->expects($this->once())
             ->method('getRepository')
             ->will($this->returnValue($this->repository))
         ;
+
         $this->repository->expects($this->once())
             ->method('getDescriptor')
             ->with(RepositoryInterface::OPTION_WORKSPACE_MANAGEMENT_SUPPORTED)
             ->will($this->returnValue(true))
         ;
+
         $this->workspace->expects($this->once())
             ->method('deleteWorkspace')
             ->with('test_workspace')
@@ -52,15 +56,16 @@ class WorkspaceDeleteCommandTest extends BaseCommandTest
             ->method('getWorkspace')
             ->will($this->returnValue($this->workspace))
         ;
+
         $this->workspace->expects($this->once())
             ->method('getAccessibleWorkspaceNames')
-            ->will($this->returnValue(array('default', 'other')))
+            ->will($this->returnValue(['default', 'other']))
         ;
 
-        $ct = $this->executeCommand('phpcr:workspace:delete', array(
+        $ct = $this->executeCommand('phpcr:workspace:delete', [
             'name' => 'test_workspace',
             '--force' => 'true',
-        ));
+        ]);
 
         $this->assertContains("Workspace 'test_workspace' does not exist.", $ct->getDisplay());
     }

--- a/tests/PHPCR/Tests/Util/Console/Command/WorkspaceExportCommandTest.php
+++ b/tests/PHPCR/Tests/Util/Console/Command/WorkspaceExportCommandTest.php
@@ -2,7 +2,6 @@
 
 namespace PHPCR\Tests\Util\Console\Command;
 
-use Symfony\Component\Console\Application;
 use PHPCR\Util\Console\Command\WorkspaceExportCommand;
 use PHPCR\RepositoryInterface;
 
@@ -11,6 +10,7 @@ class WorkspaceExportCommandTest extends BaseCommandTest
     public function setUp()
     {
         parent::setUp();
+
         $this->application->add(new WorkspaceExportCommand());
     }
 
@@ -24,21 +24,23 @@ class WorkspaceExportCommandTest extends BaseCommandTest
         $this->session->expects($this->once())
             ->method('getRepository')
             ->will($this->returnValue($this->repository));
+
         $this->repository->expects($this->once())
             ->method('getDescriptor')
             ->with(RepositoryInterface::OPTION_XML_EXPORT_SUPPORTED)
             ->will($this->returnValue(true));
+
         $this->session->expects($this->once())
             ->method('exportSystemView');
 
         $this->assertFileNotExists('test', 'test export file must not exist, it will be overwritten');
 
-        $ct = $this->executeCommand('phpcr:workspace:export', array(
+        $ct = $this->executeCommand('phpcr:workspace:export', [
             'filename' => 'test'
-        ));
+        ]);
 
         if (method_exists($ct, 'getStatusCode')) {
-            // only available since symfony 2.4
+            // Only available since symfony 2.4
             $this->assertEquals(0, $ct->getStatusCode());
         }
         $this->assertFileExists('test');

--- a/tests/PHPCR/Tests/Util/Console/Command/WorkspaceImportCommandTest.php
+++ b/tests/PHPCR/Tests/Util/Console/Command/WorkspaceImportCommandTest.php
@@ -2,7 +2,6 @@
 
 namespace PHPCR\Tests\Util\Console\Command;
 
-use Symfony\Component\Console\Application;
 use PHPCR\Util\Console\Command\WorkspaceImportCommand;
 use PHPCR\RepositoryInterface;
 
@@ -11,6 +10,7 @@ class WorkspaceImportCommandTest extends BaseCommandTest
     public function setUp()
     {
         parent::setUp();
+
         $this->application->add(new WorkspaceImportCommand());
     }
 
@@ -19,16 +19,18 @@ class WorkspaceImportCommandTest extends BaseCommandTest
         $this->session->expects($this->once())
             ->method('getRepository')
             ->will($this->returnValue($this->repository));
+
         $this->repository->expects($this->once())
             ->method('getDescriptor')
             ->with(RepositoryInterface::OPTION_XML_IMPORT_SUPPORTED)
             ->will($this->returnValue(true));
+
         $this->session->expects($this->once())
             ->method('importXml');
 
-        $ct = $this->executeCommand('phpcr:workspace:import', array(
+        $ct = $this->executeCommand('phpcr:workspace:import', [
             'filename' => 'test_import.xml'
-        ));
+        ]);
 
         $this->assertContains('Successfully imported', $ct->getDisplay());
     }

--- a/tests/PHPCR/Tests/Util/Console/Command/WorkspaceListCommandTest.php
+++ b/tests/PHPCR/Tests/Util/Console/Command/WorkspaceListCommandTest.php
@@ -2,7 +2,6 @@
 
 namespace PHPCR\Tests\Util\Console\Command;
 
-use Symfony\Component\Console\Application;
 use PHPCR\Util\Console\Command\WorkspaceListCommand;
 
 class WorkspaceListCommandTest extends BaseCommandTest
@@ -10,6 +9,7 @@ class WorkspaceListCommandTest extends BaseCommandTest
     public function setUp()
     {
         parent::setUp();
+
         $this->application->add(new WorkspaceListCommand());
     }
 
@@ -18,11 +18,12 @@ class WorkspaceListCommandTest extends BaseCommandTest
         $this->session->expects($this->once())
             ->method('getWorkspace')
             ->will($this->returnValue($this->workspace));
+
         $this->workspace->expects($this->once())
             ->method('getAccessibleWorkspaceNames')
-            ->will($this->returnValue(array(
+            ->will($this->returnValue([
                 'foo', 'bar'
-            )));
+            ]));
 
         $ct = $this->executeCommand('phpcr:workspace:list', array(
         ));

--- a/tests/PHPCR/Tests/Util/Console/Command/WorkspacePurgeCommandTest.php
+++ b/tests/PHPCR/Tests/Util/Console/Command/WorkspacePurgeCommandTest.php
@@ -2,7 +2,6 @@
 
 namespace PHPCR\Tests\Util\Console\Command;
 
-use Symfony\Component\Console\Application;
 use PHPCR\Util\Console\Command\WorkspacePurgeCommand;
 
 class WorkspacePurgeCommandTest extends BaseCommandTest
@@ -10,6 +9,7 @@ class WorkspacePurgeCommandTest extends BaseCommandTest
     public function setUp()
     {
         parent::setUp();
+
         $this->application->add(new WorkspacePurgeCommand());
     }
 
@@ -18,15 +18,17 @@ class WorkspacePurgeCommandTest extends BaseCommandTest
         $this->session->expects($this->once())
             ->method('getRootNode')
             ->will($this->returnValue($this->node1));
+
         $this->node1->expects($this->once())
             ->method('getProperties')
-            ->will($this->returnValue(array()));
+            ->will($this->returnValue([]));
+
         $this->node1->expects($this->once())
             ->method('getNodes')
-            ->will($this->returnValue(array()));
+            ->will($this->returnValue([]));
 
-        $ct = $this->executeCommand('phpcr:workspace:purge', array(
+        $this->executeCommand('phpcr:workspace:purge', [
             '--force' => true,
-        ));
+        ]);
     }
 }

--- a/tests/PHPCR/Tests/Util/Console/Command/WorkspaceQueryCommandTest.php
+++ b/tests/PHPCR/Tests/Util/Console/Command/WorkspaceQueryCommandTest.php
@@ -2,42 +2,54 @@
 
 namespace PHPCR\Tests\Util\Console\Command;
 
-use Symfony\Component\Console\Application;
+use PHPCR\Query\QueryInterface;
 use PHPCR\Util\Console\Command\WorkspaceQueryCommand;
+use PHPUnit_Framework_MockObject_MockObject;
 
 class WorkspaceQueryCommandTest extends BaseCommandTest
 {
+    /**
+     * @var QueryInterface|PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $query;
+
     public function setUp()
     {
         parent::setUp();
+
         $this->application->add(new WorkspaceQueryCommand());
-        $this->query = $this->getMock('PHPCR\Query\QueryInterface');
+        $this->query = $this->createMock(QueryInterface::class);
     }
 
     public function testQuery()
     {
         $this->queryManager->expects($this->any())
             ->method('getSupportedQueryLanguages')
-            ->will($this->returnValue(array('JCR-SQL2')));
+            ->will($this->returnValue(['JCR-SQL2']));
+
         $this->session->expects($this->any())
             ->method('getWorkspace')
             ->will($this->returnValue($this->workspace));
+
         $this->workspace->expects($this->any())
             ->method('getQueryManager')
             ->will($this->returnValue($this->queryManager));
+
         $this->queryManager->expects($this->once())
             ->method('createQuery')
             ->with('SELECT foo FROM foo', 'JCR-SQL2')
             ->will($this->returnValue($this->query));
+
         $this->query->expects($this->once())
             ->method('getLanguage')
             ->will($this->returnValue('FOOBAR'));
+
         $this->query->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue(array()));
+            ->will($this->returnValue([]));
 
-        $ct = $this->executeCommand('phpcr:workspace:query', array(
+        $this->executeCommand('phpcr:workspace:query', [
             'query' => 'SELECT foo FROM foo',
-        ));
+        ]);
     }
 }

--- a/tests/PHPCR/Tests/Util/Console/Helper/PhpcrConsoleDumperHelperTest.php
+++ b/tests/PHPCR/Tests/Util/Console/Helper/PhpcrConsoleDumperHelperTest.php
@@ -1,6 +1,9 @@
 <?php
 
 use PHPCR\Util\Console\Helper\PhpcrConsoleDumperHelper;
+use PHPCR\Util\Console\Helper\TreeDumper\ConsoleDumperPropertyVisitor;
+use PHPCR\Util\TreeWalker;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class PhpcrConsoleDumperHelperTest extends PHPUnit_Framework_TestCase
 {
@@ -12,18 +15,13 @@ class PhpcrConsoleDumperHelperTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->outputMock = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+        $this->outputMock = $this->createMock(OutputInterface::class);
         $this->helper = new PhpcrConsoleDumperHelper;
     }
 
     public function provideHelper()
     {
-        return array(
-            array(array()),
-            array(array(
-                'show_props' => true,
-            )),
-        );
+        return [[[]], [['show_props' => true]]];
     }
 
     /**
@@ -31,29 +29,23 @@ class PhpcrConsoleDumperHelperTest extends PHPUnit_Framework_TestCase
      */
     public function testGetTreeWalker($options)
     {
-        $options = array_merge(array(
+        $options = array_merge([
             'dump_uuids' => false,
             'ref_format' => 'uuid',
             'show_props' => false,
             'show_sys_nodes' => false,
-        ), $options);
+        ], $options);
 
         $tw = $this->helper->getTreeWalker($this->outputMock, $options);
-        $this->assertInstanceOf(
-            'PHPCR\Util\TreeWalker',
-            $tw
-        );
+        $this->assertInstanceOf(TreeWalker::class, $tw);
 
-        $refl = new \ReflectionClass($tw);
-        $propVisitorProp = $refl->getProperty('propertyVisitor');
+        $reflection = new ReflectionClass($tw);
+        $propVisitorProp = $reflection->getProperty('propertyVisitor');
         $propVisitorProp->setAccessible(true);
         $propVisitor = $propVisitorProp->getValue($tw);
 
         if ($options['show_props'] === true) {
-            $this->assertInstanceOf(
-                'PHPCR\Util\Console\Helper\TreeDumper\ConsoleDumperPropertyVisitor',
-                $propVisitor
-            );
+            $this->assertInstanceOf(ConsoleDumperPropertyVisitor::class, $propVisitor);
         } else {
             $this->assertNull($propVisitor);
         }

--- a/tests/PHPCR/Tests/Util/PathHelperTest.php
+++ b/tests/PHPCR/Tests/Util/PathHelperTest.php
@@ -2,7 +2,10 @@
 
 namespace PHPCR\Tests\Util;
 
+use PHPCR\NamespaceException;
+use PHPCR\RepositoryException;
 use PHPCR\Util\PathHelper;
+use stdClass;
 
 class PathHelperTest extends \PHPUnit_Framework_TestCase
 {
@@ -18,22 +21,23 @@ class PathHelperTest extends \PHPUnit_Framework_TestCase
 
     public function dataproviderValidAbsolutePaths()
     {
-        return array(
-            array('/parent/child'),
-            array('/'),
-            array('/jcr:foo_/b-a/0^.txt'),
-            array('/parent[7]/child'),
-            array('/parent[7]/child', true), // index is allowed in destination parent path, only not in last element
-            array('/parent[7]/child[3]'),
-        );
+        return [
+            ['/parent/child'],
+            ['/'],
+            ['/jcr:foo_/b-a/0^.txt'],
+            ['/parent[7]/child'],
+            ['/parent[7]/child', true], // index is allowed in destination parent path, only not in last element
+            ['/parent[7]/child[3]'],
+        ];
     }
 
     /**
      * @dataProvider dataproviderInvalidAbsolutePaths
-     * @expectedException \PHPCR\RepositoryException
      */
     public function testAssertInvalidAbsolutePath($path, $destination = false)
     {
+        $this->expectException(RepositoryException::class);
+
         PathHelper::assertValidAbsolutePath($path, $destination);
     }
 
@@ -42,31 +46,32 @@ class PathHelperTest extends \PHPUnit_Framework_TestCase
      */
     public function testAssertAbsolutePathNamespace($path)
     {
-        $this->assertTrue(PathHelper::assertValidAbsolutePath($path, false, true, array('jcr', 'nt')));
+        $this->assertTrue(PathHelper::assertValidAbsolutePath($path, false, true, ['jcr', 'nt']));
     }
 
     public function dataproviderValidAbsolutePathsWithNamespaces()
     {
-        return array(
-            array('/parent/child'),
-            array('/jcr:localname'),
-            array('/jcr:localname/test'),
-            array('/jcr:localname/test/nt:node'),
-            array('/jcr:localname/test/nt:node/bla'),
-            array('/'),
-            array('/jcr:foo_/b-a/0^.txt'),
-            array('/parent[7]/child'),
-            array('/jcr:localname[3]/test'),
-        );
+        return [
+            ['/parent/child'],
+            ['/jcr:localname'],
+            ['/jcr:localname/test'],
+            ['/jcr:localname/test/nt:node'],
+            ['/jcr:localname/test/nt:node/bla'],
+            ['/'],
+            ['/jcr:foo_/b-a/0^.txt'],
+            ['/parent[7]/child'],
+            ['/jcr:localname[3]/test'],
+        ];
     }
 
     /**
-     * @expectedException \PHPCR\NamespaceException
      * @expectedExceptionMessage invalidprefix and other-ns
      */
     public function testAssertInvalidNamespaceAbsolutePath()
     {
-        PathHelper::assertValidAbsolutePath('/invalidprefix:localname/other-ns:test/invalidprefix:node/bla', false, true, array('jcr', 'nt'));
+        $this->expectException(NamespaceException::class);
+
+        PathHelper::assertValidAbsolutePath('/invalidprefix:localname/other-ns:test/invalidprefix:node/bla', false, true, ['jcr', 'nt']);
     }
 
     /**
@@ -79,15 +84,15 @@ class PathHelperTest extends \PHPUnit_Framework_TestCase
 
     public function dataproviderInvalidAbsolutePaths()
     {
-        return array(
-            array('/parent/child[7]', true), // destination last element with index
-            array('parent'), // not absolute
-            array('/parent//child'),
-            array('//'),
-            array('/parent/../child'),
-            array('/parent/./child'),
-            array('/parent/child/'),
-        );
+        return [
+            ['/parent/child[7]', true], // destination last element with index
+            ['parent'], // not absolute
+            ['/parent//child'],
+            ['//'],
+            ['/parent/../child'],
+            ['/parent/./child'],
+            ['/parent/child/'],
+        ];
     }
 
     // assertValidLocalName tests
@@ -104,21 +109,22 @@ class PathHelperTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider dataproviderInvalidLocalNames
-     * @expectedException \PHPCR\RepositoryException
      */
     public function testAssertInvalidLocalName($name)
     {
+        $this->expectException(RepositoryException::class);
+
         PathHelper::assertValidLocalName($name);
     }
 
     public function dataproviderInvalidLocalNames()
     {
-        return array(
-            array('jcr:nodename'),
-            array('/path'),
-            array('.'),
-            array('..')
-        );
+        return [
+            ['jcr:nodename'],
+            ['/path'],
+            ['.'],
+            ['..']
+        ];
     }
 
     // normalizePath tests
@@ -133,21 +139,22 @@ class PathHelperTest extends \PHPUnit_Framework_TestCase
 
     public static function dataproviderNormalizePath()
     {
-        return array(
-            array('/',           '/'),
-            array('/../foo',     '/foo'),
-            array('/../',        '/'),
-            array('/foo/../bar', '/bar'),
-            array('/foo/./bar',  '/foo/bar'),
-        );
+        return [
+            ['/',           '/'],
+            ['/../foo',     '/foo'],
+            ['/../',        '/'],
+            ['/foo/../bar', '/bar'],
+            ['/foo/./bar',  '/foo/bar'],
+        ];
     }
 
     /**
      * @dataProvider dataproviderNormalizePathInvalid
-     * @expectedException \PHPCR\RepositoryException
      */
     public function testNormalizePathInvalidThrow($input)
     {
+        $this->expectException(RepositoryException::class);
+
         PathHelper::normalizePath($input);
     }
 
@@ -161,13 +168,13 @@ class PathHelperTest extends \PHPUnit_Framework_TestCase
 
     public static function dataproviderNormalizePathInvalid()
     {
-        return array(
-            array('foo/bar'),
-            array('bar'),
-            array('/foo/bar/'),
-            array(''),
-            array(new \stdClass()),
-        );
+        return [
+            ['foo/bar'],
+            ['bar'],
+            ['/foo/bar/'],
+            [''],
+            [new stdClass()],
+        ];
     }
 
     // absolutizePath tests
@@ -182,12 +189,12 @@ class PathHelperTest extends \PHPUnit_Framework_TestCase
 
     public static function dataproviderAbsolutizePath()
     {
-        return array(
-            array('/../foo',    '/',    '/foo'),
-            array('../',        '/',    '/'),
-            array('../foo/bar', '/baz', '/foo/bar'),
-            array('foo/./bar',  '/baz', '/baz/foo/bar'),
-        );
+        return [
+            ['/../foo',    '/',    '/foo'],
+            ['../',        '/',    '/'],
+            ['../foo/bar', '/baz', '/foo/bar'],
+            ['foo/./bar',  '/baz', '/baz/foo/bar'],
+        ];
     }
 
     /**
@@ -209,13 +216,13 @@ class PathHelperTest extends \PHPUnit_Framework_TestCase
 
     public static function dataproviderAbsolutizePathInvalid()
     {
-        return array(
-            array('', '/context', false),
-            array(null,    '/context',    false),
-            array('foo',        null,    false),
-            array(new \stdClass(), '/context', false),
-            array('foo[2]',  '/bar', true),
-        );
+        return [
+            ['', '/context', false],
+            [null,    '/context',    false],
+            ['foo',        null,    false],
+            [new stdClass(), '/context', false],
+            ['foo[2]',  '/bar', true],
+        ];
     }
 
     // relativizePath tests
@@ -230,18 +237,19 @@ class PathHelperTest extends \PHPUnit_Framework_TestCase
 
     public static function dataproviderRelativizePath()
     {
-        return array(
-            array('/parent/path/child', '/parent', 'path/child'),
-            array('/child', '/', 'child'),
-        );
+        return [
+            ['/parent/path/child', '/parent', 'path/child'],
+            ['/child', '/', 'child'],
+        ];
     }
 
     /**
-     * @expectedException \PHPCR\RepositoryException
      * @dataProvider dataproviderRelativizePathInvalid
      */
     public function testRelativizePathInvalidThrow($inputPath, $context)
     {
+        $this->expectException(RepositoryException::class);
+
         PathHelper::relativizePath($inputPath, $context);
     }
 
@@ -255,10 +263,10 @@ class PathHelperTest extends \PHPUnit_Framework_TestCase
 
     public static function dataproviderRelativizePathInvalid()
     {
-        return array(
-            array('/path', '/context'),
-            array('/parent', '/parent/child'),
-        );
+        return [
+            ['/path', '/context'],
+            ['/parent', '/parent/child'],
+        ];
     }
 
     // getParentPath tests
@@ -273,12 +281,12 @@ class PathHelperTest extends \PHPUnit_Framework_TestCase
 
     public function dataproviderParentPath()
     {
-        return array(
-            array('/parent/child', '/parent'),
-            array('/jcr:parent/ns:child', '/jcr:parent'),
-            array('/child', '/'),
-            array('/', '/'),
-        );
+        return [
+            ['/parent/child', '/parent'],
+            ['/jcr:parent/ns:child', '/jcr:parent'],
+            ['/child', '/'],
+            ['/', '/'],
+        ];
     }
 
     // getNodeName tests
@@ -310,21 +318,22 @@ class PathHelperTest extends \PHPUnit_Framework_TestCase
 
     public function dataproviderGetLocalNodeName()
     {
-        return array(
-            array('/parent/child', 'child'),
-            array('/foo:child', 'child'),
-            array('/parent/ns:child', 'child'),
-            array('/ns:parent/child:foo', 'foo'),
-            array('/', ''),
-        );
+        return [
+            ['/parent/child', 'child'],
+            ['/foo:child', 'child'],
+            ['/parent/ns:child', 'child'],
+            ['/ns:parent/child:foo', 'foo'],
+            ['/', ''],
+        ];
     }
 
     /**
-     * @expectedException \PHPCR\RepositoryException
      * @expectedExceptionMessage must be an absolute path
      */
     public function testGetNodeNameMustBeAbsolute()
     {
+        $this->expectException(RepositoryException::class);
+
         PathHelper::getNodeName('foobar');
     }
 
@@ -340,11 +349,11 @@ class PathHelperTest extends \PHPUnit_Framework_TestCase
 
     public function dataproviderPathDepth()
     {
-        return array(
-            array('/', 0),
-            array('/foo', 1),
-            array('/foo/bar', 2),
-            array('/foo/bar/', 2),
-        );
+        return [
+            ['/', 0],
+            ['/foo', 1],
+            ['/foo/bar', 2],
+            ['/foo/bar/', 2],
+        ];
     }
 }

--- a/tests/PHPCR/Tests/Util/QOM/BaseSqlGeneratorTest.php
+++ b/tests/PHPCR/Tests/Util/QOM/BaseSqlGeneratorTest.php
@@ -2,14 +2,13 @@
 
 namespace PHPCR\Tests\Util\QOM;
 
-use PHPCR\Util\QOM\Sql1Generator;
-use PHPCR\Util\ValueConverter;
+use PHPUnit_Framework_TestCase;
 
-abstract class BaseSqlGeneratorTest extends \PHPUnit_Framework_TestCase
+abstract class BaseSqlGeneratorTest extends PHPUnit_Framework_TestCase
 {
     public function testNot()
     {
-        $string = $this->generator->evalNot("foo = bar");
-        $this->assertSame("(NOT foo = bar)", $string);
+        $string = $this->generator->evalNot('foo = bar');
+        $this->assertSame('(NOT foo = bar)', $string);
     }
 }

--- a/tests/PHPCR/Tests/Util/QOM/QueryBuilderTest.php
+++ b/tests/PHPCR/Tests/Util/QOM/QueryBuilderTest.php
@@ -2,15 +2,32 @@
 
 namespace PHPCR\Tests\Util\QOM;
 
+use InvalidArgumentException;
+use PHPCR\Query\QOM\ConstraintInterface;
+use PHPCR\Query\QOM\DynamicOperandInterface;
+use PHPCR\Query\QOM\QueryObjectModelConstantsInterface;
+use PHPCR\Query\QOM\QueryObjectModelFactoryInterface;
+use PHPCR\Query\QOM\QueryObjectModelInterface;
+use PHPCR\Query\QOM\SameNodeJoinConditionInterface;
+use PHPCR\Query\QOM\SourceInterface;
 use PHPCR\Util\QOM\QueryBuilder;
+use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit_Framework_TestCase;
+use RuntimeException;
 
-class QueryBuilderTest extends \PHPUnit_Framework_TestCase
+class QueryBuilderTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @var PHPUnit_Framework_MockObject_MockObject|QueryObjectModelFactoryInterface
+     */
     protected $qf;
 
     public function setUp()
     {
-        $this->qf = $this->getMock('PHPCR\Query\QOM\QueryObjectModelFactoryInterface', array(), array());
+        $this->qf = $this->getMockBuilder(QueryObjectModelFactoryInterface::class)
+            ->setMethods([])
+            ->setConstructorArgs([])
+            ->getMock();
     }
 
     public function testSetFirstResult()
@@ -27,9 +44,25 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(15, $qb->getMaxResults());
     }
 
+    /**
+     * @return DynamicOperandInterface
+     */
+    private function createDynamicOperandMock()
+    {
+        /** @var DynamicOperandInterface $dynamicOperand */
+        $dynamicOperand = $this->getMockBuilder(DynamicOperandInterface::class)
+            ->setMethods([])
+            ->setConstructorArgs([])
+            ->getMock()
+        ;
+
+        return $dynamicOperand;
+    }
+
     public function testAddOrderBy()
     {
-        $dynamicOperand = $this->getMock('PHPCR\Query\QOM\DynamicOperandInterface', array(), array());
+        $dynamicOperand = $this->createDynamicOperandMock();
+
         $qb = new QueryBuilder($this->qf);
         $qb->addOrderBy($dynamicOperand, 'ASC');
         $qb->addOrderBy($dynamicOperand, 'DESC');
@@ -39,7 +72,8 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testAddOrderByLowercase()
     {
-        $dynamicOperand = $this->getMock('PHPCR\Query\QOM\DynamicOperandInterface', array(), array());
+        $dynamicOperand = $this->createDynamicOperandMock();
+
         $qb = new QueryBuilder($this->qf);
         $qb->addOrderBy($dynamicOperand, 'asc');
         $qb->addOrderBy($dynamicOperand, 'desc');
@@ -47,19 +81,20 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase
         $orderings = $qb->getOrderings();
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testAddOrderByInvalid()
     {
-        $dynamicOperand = $this->getMock('PHPCR\Query\QOM\DynamicOperandInterface', array(), array());
+        $this->expectException(InvalidArgumentException::class);
+
+        $dynamicOperand = $this->createDynamicOperandMock();
+
         $qb = new QueryBuilder($this->qf);
         $qb->addOrderBy($dynamicOperand, 'FOO');
     }
 
     public function testOrderBy()
     {
-        $dynamicOperand = $this->getMock('PHPCR\Query\QOM\DynamicOperandInterface', array(), array());
+        $dynamicOperand = $this->createDynamicOperandMock();
+
         $qb = new QueryBuilder($this->qf);
         $qb->orderBy($dynamicOperand, 'ASC');
         $qb->orderBy($dynamicOperand, 'ASC');
@@ -68,37 +103,59 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testOrderAscending()
     {
-        $dynamicOperand = $this->getMock('PHPCR\Query\QOM\DynamicOperandInterface', array(), array());
+        $dynamicOperand = $this->createDynamicOperandMock();
+
         $this->qf->expects($this->once())
                  ->method('ascending')
                  ->with($this->equalTo($dynamicOperand));
+
         $qb = new QueryBuilder($this->qf);
         $qb->addOrderBy($dynamicOperand, 'ASC');
     }
 
     public function testOrderDescending()
     {
-        $dynamicOperand = $this->getMock('PHPCR\Query\QOM\DynamicOperandInterface', array(), array());
+        $dynamicOperand = $this->createDynamicOperandMock();
+
         $this->qf->expects($this->once())
                  ->method('descending')
                  ->with($this->equalTo($dynamicOperand));
+
         $qb = new QueryBuilder($this->qf);
         $qb->addOrderBy($dynamicOperand, 'DESC');
     }
 
     public function testOrderAscendingIsDefault()
     {
-        $dynamicOperand = $this->getMock('PHPCR\Query\QOM\DynamicOperandInterface', array(), array());
+        $dynamicOperand = $this->createDynamicOperandMock();
+
         $this->qf->expects($this->once())
                  ->method('ascending')
                  ->with($this->equalTo($dynamicOperand));
+
         $qb = new QueryBuilder($this->qf);
         $qb->addOrderBy($dynamicOperand);
     }
 
+    /**
+     * @return ConstraintInterface
+     */
+    private function createConstraintMock()
+    {
+        /** @var ConstraintInterface $constraint */
+        $constraint = $this->getMockBuilder(ConstraintInterface::class)
+            ->setMethods([])
+            ->setConstructorArgs([])
+            ->getMock()
+        ;
+
+        return $constraint;
+    }
+
     public function testWhere()
     {
-        $constraint = $this->getMock('PHPCR\Query\QOM\ConstraintInterface', array(), array());
+        $constraint = $this->createConstraintMock();
+
         $qb = new QueryBuilder($this->qf);
         $qb->where($constraint);
         $this->assertEquals($constraint, $qb->getConstraint());
@@ -106,13 +163,12 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testAndWhere()
     {
-        $dynamicOperand = $this->getMock('PHPCR\Query\QOM\ConstraintInterface', array(), array());
-        $this->qf = $this->getMock('PHPCR\Query\QOM\QueryObjectModelFactoryInterface', array(), array());
         $this->qf->expects($this->once())
                  ->method('andConstraint');
 
-        $constraint1 = $this->getMock('PHPCR\Query\QOM\ConstraintInterface', array(), array());
-        $constraint2 = $this->getMock('PHPCR\Query\QOM\ConstraintInterface', array(), array());
+        $constraint1 = $this->createConstraintMock();
+        $constraint2 = $this->createConstraintMock();
+
         $qb = new QueryBuilder($this->qf);
         $qb->where($constraint1);
         $qb->andWhere($constraint2);
@@ -120,13 +176,12 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testOrWhere()
     {
-        $dynamicOperand = $this->getMock('PHPCR\Query\QOM\ConstraintInterface', array(), array());
-        $this->qf = $this->getMock('PHPCR\Query\QOM\QueryObjectModelFactoryInterface', array(), array());
         $this->qf->expects($this->once())
                  ->method('orConstraint');
 
-        $constraint1 = $this->getMock('PHPCR\Query\QOM\ConstraintInterface', array(), array());
-        $constraint2 = $this->getMock('PHPCR\Query\QOM\ConstraintInterface', array(), array());
+        $constraint1 = $this->createConstraintMock();
+        $constraint2 = $this->createConstraintMock();
+
         $qb = new QueryBuilder($this->qf);
         $qb->where($constraint1);
         $qb->orWhere($constraint2);
@@ -152,31 +207,70 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(2, $qb->getColumns());
     }
 
+    /**
+     * @return SourceInterface
+     */
+    private function createSourceMock()
+    {
+        /** @var SourceInterface $source */
+        $source = $this->getMockBuilder(SourceInterface::class)
+            ->setMethods([])
+            ->setConstructorArgs([])
+            ->getMock();
+
+        return $source;
+    }
+
     public function testFrom()
     {
-        $source = $this->getMock('PHPCR\Query\QOM\SourceInterface', array(), array());
+        $source = $this->createSourceMock();
+
         $qb = new QueryBuilder($this->qf);
         $qb->from($source);
         $this->assertEquals($source, $qb->getSource());
     }
 
+    /**
+     * @return SameNodeJoinConditionInterface
+     */
+    private function createSameNodeJoinConditionMock()
+    {
+        /** @var SameNodeJoinConditionInterface $joinCondition */
+        $joinCondition = $this->getMockBuilder(SameNodeJoinConditionInterface::class)
+            ->setMethods([])
+            ->setConstructorArgs([])
+            ->getMock();
+
+        return $joinCondition;
+    }
+
     public function testInvalidJoin()
     {
-        $this->setExpectedException('\RuntimeException');
-        $source = $this->getMock('PHPCR\Query\QOM\SourceInterface', array(), array());
-        $joinCondition = $this->getMock('PHPCR\Query\QOM\SameNodeJoinConditionInterface', array(), array());
+        $this->expectException(RuntimeException::class);
+
+        $source = $this->createSourceMock();
+        $joinCondition = $this->createSameNodeJoinConditionMock();
+
         $qb = new QueryBuilder($this->qf);
         $qb->join($source, $joinCondition);
     }
 
     public function testJoin()
     {
-        $source1 = $this->getMock('PHPCR\Query\QOM\SourceInterface', array(), array());
-        $source2= $this->getMock('PHPCR\Query\QOM\SourceInterface', array(), array());
-        $joinCondition = $this->getMock('PHPCR\Query\QOM\SameNodeJoinConditionInterface', array(), array());
+        $source1 = $this->createSourceMock();
+        $source2 = $this->createSourceMock();
+        $joinCondition = $this->createSameNodeJoinConditionMock();
+
         $this->qf->expects($this->once())
             ->method('join')
-            ->with($source1, $source2, $this->equalTo(\PHPCR\Query\QOM\QueryObjectModelConstantsInterface::JCR_JOIN_TYPE_INNER), $joinCondition);
+            ->with(
+                $source1,
+                $source2,
+                $this->equalTo(QueryObjectModelConstantsInterface::JCR_JOIN_TYPE_INNER),
+                $joinCondition
+            )
+        ;
+
         $qb = new QueryBuilder($this->qf);
         $qb->from($source1);
         $qb->join($source2, $joinCondition);
@@ -184,12 +278,20 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testRightJoin()
     {
-        $source1 = $this->getMock('PHPCR\Query\QOM\SourceInterface', array(), array());
-        $source2= $this->getMock('PHPCR\Query\QOM\SourceInterface', array(), array());
-        $joinCondition = $this->getMock('PHPCR\Query\QOM\SameNodeJoinConditionInterface', array(), array());
+        $source1 = $this->createSourceMock();
+        $source2 = $this->createSourceMock();
+        $joinCondition = $this->createSameNodeJoinConditionMock();
+
         $this->qf->expects($this->once())
                  ->method('join')
-                 ->with($source1, $source2, $this->equalTo(\PHPCR\Query\QOM\QueryObjectModelConstantsInterface::JCR_JOIN_TYPE_RIGHT_OUTER), $joinCondition);
+                 ->with(
+                     $source1,
+                     $source2,
+                     $this->equalTo(QueryObjectModelConstantsInterface::JCR_JOIN_TYPE_RIGHT_OUTER),
+                     $joinCondition
+                 )
+        ;
+
         $qb = new QueryBuilder($this->qf);
         $qb->from($source1);
         $qb->rightJoin($source2, $joinCondition);
@@ -197,12 +299,20 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testLeftJoin()
     {
-        $source1 = $this->getMock('PHPCR\Query\QOM\SourceInterface', array(), array());
-        $source2= $this->getMock('PHPCR\Query\QOM\SourceInterface', array(), array());
-        $joinCondition = $this->getMock('PHPCR\Query\QOM\SameNodeJoinConditionInterface', array(), array());
+        $source1 = $this->createSourceMock();
+        $source2 = $this->createSourceMock();
+        $joinCondition = $this->createSameNodeJoinConditionMock();
+
         $this->qf->expects($this->once())
-                 ->method('join')
-                 ->with($source1, $source2, $this->equalTo(\PHPCR\Query\QOM\QueryObjectModelConstantsInterface::JCR_JOIN_TYPE_LEFT_OUTER), $joinCondition);
+            ->method('join')
+            ->with(
+                $source1,
+                $source2,
+                $this->equalTo(QueryObjectModelConstantsInterface::JCR_JOIN_TYPE_LEFT_OUTER),
+                $joinCondition
+            )
+        ;
+
         $qb = new QueryBuilder($this->qf);
         $qb->from($source1);
         $qb->leftJoin($source2, $joinCondition);
@@ -210,69 +320,99 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testGetQuery()
     {
-        $source = $this->getMock('PHPCR\Query\QOM\SourceInterface', array(), array());
-        $constraint = $this->getMock('PHPCR\Query\QOM\ConstraintInterface', array(), array());
+        $source = $this->createSourceMock();
+        $constraint = $this->createConstraintMock();
+
         $qb = new QueryBuilder($this->qf);
         $qb->from($source);
         $qb->where($constraint);
+
         $this->qf->expects($this->once())
                  ->method('createQuery')
-                 ->will($this->returnValue("true"));
+                 ->will($this->returnValue('true'));
+
         $qb->getQuery();
     }
+
+    /**
+     * @return QueryObjectModelInterface|PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createQueryMock()
+    {
+        /** @var QueryObjectModelInterface $query */
+        $query = $this->getMockBuilder(QueryObjectModelInterface::class)
+            ->setMethods([])
+            ->setConstructorArgs([])
+            ->getMock()
+        ;
+
+        return $query;
+    }
+
     public function testGetQueryWithOffsetAndLimit()
     {
-        $source = $this->getMock('PHPCR\Query\QOM\SourceInterface', array(), array());
-        $constraint = $this->getMock('PHPCR\Query\QOM\ConstraintInterface', array(), array());
-        $query = $this->getMock('PHPCR\Query\QOM\QueryObjectModelInterface', array(), array());
+        $source = $this->createSourceMock();
+        $constraint = $this->createConstraintMock();
+
+        $query = $this->createQueryMock();
+
         $qb = new QueryBuilder($this->qf);
         $qb->from($source);
         $qb->where($constraint);
         $qb->setFirstResult(13);
         $qb->setMaxResults(42);
+
         $query->expects($this->once())
               ->method('setOffset');
         $query->expects($this->once())
               ->method('setLimit');
+
         $this->qf->expects($this->once())
                  ->method('createQuery')
                  ->will($this->returnValue($query));
+
         $qb->getQuery();
     }
 
     public function testSetParameter()
     {
+        $key = 'key';
+        $value = 'value';
+
         $qb = new QueryBuilder($this->qf);
-        $key = "key";
-        $value = "value";
         $qb->setParameter($key, $value);
+
         $this->assertEquals($value, $qb->getParameter($key));
     }
 
     public function testSetParameters()
     {
+        $key1 = 'key1';
+        $value1 = 'value1';
+        $key2 = 'key2';
+        $value2 = 'value2';
+
         $qb = new QueryBuilder($this->qf);
-        $key1 = "key1";
-        $value1 = "value1";
-        $key2 = "key2";
-        $value2 = "value2";
-        $qb->setParameters(array($key1, $value1), array($key2, $value2));
+        $qb->setParameters([$key1, $value1], [$key2, $value2]);
         $this->assertCount(2, $qb->getParameters());
     }
 
     public function testExecute()
     {
-        $source = $this->getMock('PHPCR\Query\QOM\SourceInterface', array(), array());
-        $constraint = $this->getMock('PHPCR\Query\QOM\ConstraintInterface', array(), array());
-        $query = $this->getMock('PHPCR\Query\QueryInterface', array(), array());
+        $source = $this->createSourceMock();
+        $constraint = $this->createConstraintMock();
+        $query = $this->createQueryMock();
+
         $query->expects($this->once())
               ->method('execute');
         $query->expects($this->once())
               ->method('bindValue');
+
         $this->qf->expects($this->once())
                  ->method('createQuery')
                  ->with($source, $constraint, array(), array())
                  ->will($this->returnValue($query));
+
         $qb = new QueryBuilder($this->qf);
         $qb->from($source)
            ->where($constraint)

--- a/tests/PHPCR/Tests/Util/QOM/Sql1GeneratorTest.php
+++ b/tests/PHPCR/Tests/Util/QOM/Sql1GeneratorTest.php
@@ -2,11 +2,16 @@
 
 namespace PHPCR\Tests\Util\QOM;
 
+use DateTime;
 use PHPCR\Util\QOM\Sql1Generator;
 use PHPCR\Util\ValueConverter;
+use PHPUnit_Framework_TestCase;
 
-class Sql1GeneratorTest extends \PHPUnit_Framework_TestCase
+class Sql1GeneratorTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @var Sql1Generator
+     */
     protected $generator;
 
     public function setUp()
@@ -22,7 +27,7 @@ class Sql1GeneratorTest extends \PHPUnit_Framework_TestCase
 
     public function testDateTimeLiteral()
     {
-        $literal = $this->generator->evalLiteral(new \DateTime('2011-12-23T00:00:00.000+00:00'));
+        $literal = $this->generator->evalLiteral(new DateTime('2011-12-23T00:00:00.000+00:00'));
         $this->assertEquals("TIMESTAMP '2011-12-23T00:00:00.000+00:00'", $literal);
     }
 
@@ -35,44 +40,44 @@ class Sql1GeneratorTest extends \PHPUnit_Framework_TestCase
     public function testLongLiteral()
     {
         $literal = $this->generator->evalLiteral(11);
-        $this->assertSame("11", $literal);
+        $this->assertSame('11', $literal);
     }
 
     public function testDoubleLiteral()
     {
         $literal = $this->generator->evalLiteral(11.0);
-        $this->assertSame("11.0", $literal);
+        $this->assertSame('11.0', $literal);
     }
 
     public function testChildNode()
     {
-        $literal = $this->generator->evalChildNode("/");
+        $literal = $this->generator->evalChildNode('/');
         $this->assertSame("jcr:path LIKE '/%' AND NOT jcr:path LIKE '/%/%'", $literal);
 
-        $literal = $this->generator->evalChildNode("/foo/bar/baz");
+        $literal = $this->generator->evalChildNode('/foo/bar/baz');
         $this->assertSame("jcr:path LIKE '/foo[%]/bar[%]/baz[%]/%' AND NOT jcr:path LIKE '/foo[%]/bar[%]/baz[%]/%/%'", $literal);
     }
 
     public function testDescendantNode()
     {
-        $literal = $this->generator->evalDescendantNode("/");
+        $literal = $this->generator->evalDescendantNode('/');
         $this->assertSame("jcr:path LIKE '/%'", $literal);
 
-        $literal = $this->generator->evalDescendantNode("/foo/bar/baz");
+        $literal = $this->generator->evalDescendantNode('/foo/bar/baz');
         $this->assertSame("jcr:path LIKE '/foo[%]/bar[%]/baz[%]/%'", $literal);
     }
 
     public function testPopertyExistence()
     {
-        $literal = $this->generator->evalPropertyExistence(null, "foo");
-        $this->assertSame("foo IS NOT NULL", $literal);
+        $literal = $this->generator->evalPropertyExistence(null, 'foo');
+        $this->assertSame('foo IS NOT NULL', $literal);
     }
 
     public function testFullTextSearch()
     {
         $literal = $this->generator->evalFullTextSearch(null, "'foo'");
         $this->assertSame("CONTAINS(*, 'foo')", $literal);
-        $literal = $this->generator->evalFullTextSearch(null, "'foo'", "bar");
+        $literal = $this->generator->evalFullTextSearch(null, "'foo'", 'bar');
         $this->assertSame("CONTAINS(bar, 'foo')", $literal);
     }
 
@@ -80,13 +85,13 @@ class Sql1GeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $literal = $this->generator->evalColumns(null);
         $this->assertSame("s", $literal);
-        $literal = $this->generator->evalColumns(array("bar", "foo"));
+        $literal = $this->generator->evalColumns(['bar', 'foo']);
         $this->assertSame("bar, foo", $literal);
     }
 
     public function testPropertyValue()
     {
-        $literal = $this->generator->evalPropertyValue("foo");
-        $this->assertSame("foo", $literal);
+        $literal = $this->generator->evalPropertyValue('foo');
+        $this->assertSame('foo', $literal);
     }
 }

--- a/tests/PHPCR/Tests/Util/QOM/Sql2GeneratorTest.php
+++ b/tests/PHPCR/Tests/Util/QOM/Sql2GeneratorTest.php
@@ -2,11 +2,15 @@
 
 namespace PHPCR\Tests\Util\QOM;
 
+use DateTime;
 use PHPCR\Util\QOM\Sql2Generator;
 use PHPCR\Util\ValueConverter;
 
 class Sql2GeneratorTest extends BaseSqlGeneratorTest
 {
+    /**
+     * @var Sql2Generator
+     */
     protected $generator;
 
     public function setUp()
@@ -22,7 +26,7 @@ class Sql2GeneratorTest extends BaseSqlGeneratorTest
 
     public function testDateTimeLiteral()
     {
-        $literal = $this->generator->evalLiteral(new \DateTime('2011-12-23T00:00:00.000+00:00'));
+        $literal = $this->generator->evalLiteral(new DateTime('2011-12-23T00:00:00.000+00:00'));
         $this->assertEquals("CAST('2011-12-23T00:00:00.000+00:00' AS DATE)", $literal);
     }
 

--- a/tests/PHPCR/Tests/Util/QOM/Sql2ToQomQueryConverterTest.php
+++ b/tests/PHPCR/Tests/Util/QOM/Sql2ToQomQueryConverterTest.php
@@ -2,26 +2,43 @@
 
 namespace PHPCR\Tests\Util\QOM;
 
+use PHPCR\Query\InvalidQueryException;
+use PHPCR\Query\QOM\QueryObjectModelFactoryInterface;
 use PHPCR\Util\QOM\Sql2ToQomQueryConverter;
+use PHPCR\Util\ValueConverter;
+use PHPUnit_Framework_TestCase;
 
-class Sql2ToQomQueryConverterTest extends \PHPUnit_Framework_TestCase
+class Sql2ToQomQueryConverterTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @var QueryObjectModelFactoryInterface
+     */
     protected $qomFactory;
+
+    /**
+     * @var ValueConverter
+     */
     protected $valueConverter;
+
+    /**
+     * @var Sql2ToQomQueryConverter
+     */
+    protected $converter;
 
     public function setUp()
     {
-        $this->qomFactory = $this->getMock('PHPCR\Query\QOM\QueryObjectModelFactoryInterface');
-        $this->valueConverter = $this->getMock('PHPCR\Util\ValueConverter');
+        $this->qomFactory = $this->createMock(QueryObjectModelFactoryInterface::class);
+        $this->valueConverter = $this->createMock(ValueConverter::class);
         $this->converter = new Sql2ToQomQueryConverter($this->qomFactory, $this->valueConverter);
     }
 
     /**
-     * @expectedException \PHPCR\Query\InvalidQueryException
      * @expectedExceptionMessage Error parsing query
      */
     public function testInvalid()
     {
+        $this->expectException(InvalidQueryException::class);
+
         $this->converter->parse('SELECTING WITH AN INVALID QUERY');
     }
 }

--- a/tests/PHPCR/Tests/Util/TraversingItemVisitorTest.php
+++ b/tests/PHPCR/Tests/Util/TraversingItemVisitorTest.php
@@ -2,7 +2,9 @@
 
 namespace PHPCR\Tests\Util;
 
-class TraversingItemVisitorTest extends \PHPUnit_Framework_TestCase
+use PHPUnit_Framework_TestCase;
+
+class TraversingItemVisitorTest extends PHPUnit_Framework_TestCase
 {
     public function testVisitor()
     {

--- a/tests/PHPCR/Tests/Util/UUIDHelperTest.php
+++ b/tests/PHPCR/Tests/Util/UUIDHelperTest.php
@@ -3,8 +3,9 @@
 namespace PHPCR\Tests\Util;
 
 use PHPCR\Util\UUIDHelper;
+use PHPUnit_Framework_TestCase;
 
-class UUIDHelperTest extends \PHPUnit_Framework_TestCase
+class UUIDHelperTest extends PHPUnit_Framework_TestCase
 {
     public function testGenerateUUID()
     {

--- a/tests/PHPCR/Tests/Util/ValueConverterTest.php
+++ b/tests/PHPCR/Tests/Util/ValueConverterTest.php
@@ -1,17 +1,24 @@
 <?php
 namespace PHPCR\Tests\Util;
 
+use DateTime;
 use PHPCR\PropertyType;
+use PHPCR\RepositoryException;
+use PHPCR\Tests\Stubs\MockNode;
 use PHPCR\Util\ValueConverter;
+use PHPCR\ValueFormatException;
+use PHPUnit_Framework_TestCase;
 
-require_once(__DIR__.'/../Stubs/MockNode.php');
+require_once __DIR__.'/../Stubs/MockNode.php';
 
 /**
- * a test for the PHPCR\PropertyType class
+ * A test for the PHPCR\PropertyType class
  */
-class ValueConverterTest extends \PHPUnit_Framework_TestCase
+class ValueConverterTest extends PHPUnit_Framework_TestCase
 {
-    /** @var  ValueConverter */
+    /**
+     * @var ValueConverter
+     */
     private $valueConverter;
 
     public function setUp()
@@ -25,268 +32,271 @@ class ValueConverterTest extends \PHPUnit_Framework_TestCase
         fwrite($stream, 'test string');
         rewind($stream);
 
-        $datestream = fopen('php://memory', '+rw');
-        fwrite($datestream, '17.12.2010  GMT');
-        rewind($datestream);
+        $dateStream = fopen('php://memory', '+rw');
+        fwrite($dateStream, '17.12.2010  GMT');
+        rewind($dateStream);
 
-        $numberstream = fopen('php://memory', '+rw');
-        fwrite($numberstream, '123.456');
-        rewind($numberstream);
+        $numberStream = fopen('php://memory', '+rw');
+        fwrite($numberStream, '123.456');
+        rewind($numberStream);
 
-        $namestream = fopen('php://memory', '+rw');
-        fwrite($namestream, 'test');
-        rewind($namestream);
+        $nameStream = fopen('php://memory', '+rw');
+        fwrite($nameStream, 'test');
+        rewind($nameStream);
 
-        $uuidstream = fopen('php://memory', '+rw');
-        fwrite($uuidstream, '38b7cf18-c417-477a-af0b-c1e92a290c9a');
-        rewind($uuidstream);
+        $uuidStream = fopen('php://memory', '+rw');
+        fwrite($uuidStream, '38b7cf18-c417-477a-af0b-c1e92a290c9a');
+        rewind($uuidStream);
 
-        $datetimeLong = new \DateTime();
+        $datetimeLong = new DateTime();
         $datetimeLong->setTimestamp(123);
 
-        $nodemock = $this->getMock('PHPCR\Tests\Stubs\MockNode');
-        $nodemock
+        $nodeMock = $this->createMock(MockNode::class);
+        $nodeMock
             ->expects($this->any())
             ->method('getIdentifier')
             ->will($this->returnValue('38b7cf18-c417-477a-af0b-c1e92a290c9a'))
         ;
-        $nodemock
+
+        $nodeMock
             ->expects($this->any())
             ->method('isNodeType')
             ->with('mix:referenceable')
             ->will($this->returnValue(true))
         ;
 
-        return array(
-            // string to...
-            array('test string', PropertyType::STRING, 'test string', PropertyType::STRING),
-            array('test string', PropertyType::STRING, 0, PropertyType::LONG),
-            array('378.37', PropertyType::STRING, 378, PropertyType::LONG),
-            array('test string', PropertyType::STRING, 0.0, PropertyType::DOUBLE),
-            array('249.39', PropertyType::STRING, 249.39, PropertyType::DOUBLE),
-            array('test string', PropertyType::STRING, null, PropertyType::DATE),
-            array('17.12.2010 GMT', PropertyType::STRING, new \DateTime('17.12.2010 GMT'), PropertyType::DATE),
-            array('test string', PropertyType::STRING, true, PropertyType::BOOLEAN),
-            array('false', PropertyType::STRING, true, PropertyType::BOOLEAN),
-            array('', PropertyType::STRING, false, PropertyType::BOOLEAN),
-            // TODO: check NAME may not have spaces array('test string', PropertyType::STRING, null, PropertyType::NAME),
-            array('test', PropertyType::STRING, 'test', PropertyType::NAME),
-            // TODO: check PATH may not have spaces array('test string', PropertyType::STRING, null, PropertyType::PATH),
-            array('../the/node', PropertyType::STRING, '../the/node', PropertyType::PATH),
-            array('38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::STRING, '38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE),
-            // TODO: should we move UUIDHelper to phpcr so we can check in PropertyType? array('test string', PropertyType::STRING, null, PropertyType::REFERENCE),
-            array('', PropertyType::STRING, null, PropertyType::REFERENCE),
-            array('http://phpcr.github.com/', PropertyType::STRING, 'http://phpcr.github.com/', PropertyType::URI),
-            array('test string', PropertyType::STRING, 'test string', PropertyType::DECIMAL), // up to the decimal functions to validate
+        return [
+            // String to...
+            ['test string', PropertyType::STRING, 'test string', PropertyType::STRING],
+            ['test string', PropertyType::STRING, 0, PropertyType::LONG],
+            ['378.37', PropertyType::STRING, 378, PropertyType::LONG],
+            ['test string', PropertyType::STRING, 0.0, PropertyType::DOUBLE],
+            ['249.39', PropertyType::STRING, 249.39, PropertyType::DOUBLE],
+            ['test string', PropertyType::STRING, null, PropertyType::DATE],
+            ['17.12.2010 GMT', PropertyType::STRING, new DateTime('17.12.2010 GMT'), PropertyType::DATE],
+            ['test string', PropertyType::STRING, true, PropertyType::BOOLEAN],
+            ['false', PropertyType::STRING, true, PropertyType::BOOLEAN],
+            ['', PropertyType::STRING, false, PropertyType::BOOLEAN],
+            // TODO: check NAME may not have spaces ['test string', PropertyType::STRING, null, PropertyType::NAME],
+            ['test', PropertyType::STRING, 'test', PropertyType::NAME],
+            // TODO: check PATH may not have spaces ['test string', PropertyType::STRING, null, PropertyType::PATH],
+            ['../the/node', PropertyType::STRING, '../the/node', PropertyType::PATH],
+            ['38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::STRING, '38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE],
+            // TODO: should we move UUIDHelper to phpcr so we can check in PropertyType? ['test string', PropertyType::STRING, null, PropertyType::REFERENCE],
+            ['', PropertyType::STRING, null, PropertyType::REFERENCE],
+            ['http://phpcr.github.com/', PropertyType::STRING, 'http://phpcr.github.com/', PropertyType::URI],
+            ['test string', PropertyType::STRING, 'test string', PropertyType::DECIMAL], // up to the decimal functions to validate
 
-            // stream to...
-            array($stream, PropertyType::BINARY, 'test string', PropertyType::STRING),
-            array($stream, PropertyType::BINARY, 0, PropertyType::LONG),
-            array($numberstream, PropertyType::BINARY, 123, PropertyType::LONG),
-            array($stream, PropertyType::BINARY, 0.0, PropertyType::DOUBLE),
-            array($numberstream, PropertyType::BINARY, 123.456, PropertyType::DOUBLE),
-            array($stream, PropertyType::BINARY, null, PropertyType::DATE),
-            array($datestream, PropertyType::BINARY, new \DateTime('17.12.2010 GMT'), PropertyType::DATE),
-            array($stream, PropertyType::BINARY, true, PropertyType::BOOLEAN),
-            // TODO: check NAME may not have spaces array($stream, PropertyType::BINARY, null, PropertyType::NAME),
-            array($namestream, PropertyType::BINARY, 'test', PropertyType::NAME),
-            // TODO: check PATH may not have spaces array($stream, PropertyType::BINARY, null, PropertyType::PATH),
-            // TODO: should we move UUIDHelper to phpcr so we can check in PropertyType? array($stream, PropertyType::STRING, null, PropertyType::REFERENCE),
-            array($uuidstream, PropertyType::BINARY, '38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE),
-            array($stream, PropertyType::BINARY, 'test string', PropertyType::DECIMAL), // up to the decimal functions to validate
+            // Stream to...
+            [$stream, PropertyType::BINARY, 'test string', PropertyType::STRING],
+            [$stream, PropertyType::BINARY, 0, PropertyType::LONG],
+            [$numberStream, PropertyType::BINARY, 123, PropertyType::LONG],
+            [$stream, PropertyType::BINARY, 0.0, PropertyType::DOUBLE],
+            [$numberStream, PropertyType::BINARY, 123.456, PropertyType::DOUBLE],
+            [$stream, PropertyType::BINARY, null, PropertyType::DATE],
+            [$dateStream, PropertyType::BINARY, new DateTime('17.12.2010 GMT'), PropertyType::DATE],
+            [$stream, PropertyType::BINARY, true, PropertyType::BOOLEAN],
+            // TODO: check NAME may not have spaces [$stream, PropertyType::BINARY, null, PropertyType::NAME],
+            [$nameStream, PropertyType::BINARY, 'test', PropertyType::NAME],
+            // TODO: check PATH may not have spaces [$stream, PropertyType::BINARY, null, PropertyType::PATH],
+            // TODO: should we move UUIDHelper to phpcr so we can check in PropertyType? [$stream, PropertyType::STRING, null, PropertyType::REFERENCE],
+            [$uuidStream, PropertyType::BINARY, '38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE],
+            [$stream, PropertyType::BINARY, 'test string', PropertyType::DECIMAL], // up to the decimal functions to validate
 
-            // invalid stream resource
-            array($stream, PropertyType::DECIMAL, null, PropertyType::STRING),
+            // Invalid stream resource
+            [$stream, PropertyType::DECIMAL, null, PropertyType::STRING],
 
-            // long to...
-            array(123, PropertyType::LONG, '123', PropertyType::STRING),
-            array(123, PropertyType::LONG, 123, PropertyType::LONG),
-            array(123, PropertyType::LONG, 123.0, PropertyType::DOUBLE),
-            array(123, PropertyType::LONG, $datetimeLong, PropertyType::DATE),
-            array(123, PropertyType::LONG, true, PropertyType::BOOLEAN),
-            array(0, PropertyType::LONG, false, PropertyType::BOOLEAN),
-            array(123, PropertyType::LONG, null, PropertyType::NAME),
-            array(123, PropertyType::LONG, null, PropertyType::PATH),
-            array(123, PropertyType::LONG, null, PropertyType::REFERENCE),
-            array(123, PropertyType::LONG, null, PropertyType::URI),
-            array(123, PropertyType::LONG, '123', PropertyType::DECIMAL),
+            // Long to...
+            [123, PropertyType::LONG, '123', PropertyType::STRING],
+            [123, PropertyType::LONG, 123, PropertyType::LONG],
+            [123, PropertyType::LONG, 123.0, PropertyType::DOUBLE],
+            [123, PropertyType::LONG, $datetimeLong, PropertyType::DATE],
+            [123, PropertyType::LONG, true, PropertyType::BOOLEAN],
+            [0, PropertyType::LONG, false, PropertyType::BOOLEAN],
+            [123, PropertyType::LONG, null, PropertyType::NAME],
+            [123, PropertyType::LONG, null, PropertyType::PATH],
+            [123, PropertyType::LONG, null, PropertyType::REFERENCE],
+            [123, PropertyType::LONG, null, PropertyType::URI],
+            [123, PropertyType::LONG, '123', PropertyType::DECIMAL],
 
-            // double to...
-            array(123.1, PropertyType::DOUBLE, '123.1', PropertyType::STRING),
-            array(123.1, PropertyType::DOUBLE, 123, PropertyType::LONG),
-            array(123.1, PropertyType::DOUBLE, 123.1, PropertyType::DOUBLE),
-            array(123.1, PropertyType::DOUBLE, $datetimeLong, PropertyType::DATE),
-            array(123.1, PropertyType::DOUBLE, true, PropertyType::BOOLEAN),
-            array(0.0, PropertyType::DOUBLE, false, PropertyType::BOOLEAN),
-            array(123.1, PropertyType::DOUBLE, null, PropertyType::NAME),
-            array(123.1, PropertyType::DOUBLE, null, PropertyType::PATH),
-            array(123.1, PropertyType::DOUBLE, null, PropertyType::REFERENCE),
-            array(123.1, PropertyType::DOUBLE, null, PropertyType::URI),
-            array(123.1, PropertyType::DOUBLE, '123.1', PropertyType::DECIMAL),
+            // Double to...
+            [123.1, PropertyType::DOUBLE, '123.1', PropertyType::STRING],
+            [123.1, PropertyType::DOUBLE, 123, PropertyType::LONG],
+            [123.1, PropertyType::DOUBLE, 123.1, PropertyType::DOUBLE],
+            [123.1, PropertyType::DOUBLE, $datetimeLong, PropertyType::DATE],
+            [123.1, PropertyType::DOUBLE, true, PropertyType::BOOLEAN],
+            [0.0, PropertyType::DOUBLE, false, PropertyType::BOOLEAN],
+            [123.1, PropertyType::DOUBLE, null, PropertyType::NAME],
+            [123.1, PropertyType::DOUBLE, null, PropertyType::PATH],
+            [123.1, PropertyType::DOUBLE, null, PropertyType::REFERENCE],
+            [123.1, PropertyType::DOUBLE, null, PropertyType::URI],
+            [123.1, PropertyType::DOUBLE, '123.1', PropertyType::DECIMAL],
 
-            // date to...
-            array($datetimeLong, PropertyType::DATE, $datetimeLong->format('Y-m-d\TH:i:s.') . substr($datetimeLong->format('u'), 0, 3) . $datetimeLong->format('P'), PropertyType::STRING),
-            array($datetimeLong, PropertyType::DATE, 123, PropertyType::LONG),
-            array($datetimeLong, PropertyType::DATE, 123.0, PropertyType::DOUBLE),
-            array($datetimeLong, PropertyType::DATE, $datetimeLong, PropertyType::DATE),
-            array($datetimeLong, PropertyType::DATE, true, PropertyType::BOOLEAN),
-            array($datetimeLong, PropertyType::DATE, null, PropertyType::NAME),
-            array($datetimeLong, PropertyType::DATE, null, PropertyType::PATH),
-            array($datetimeLong, PropertyType::DATE, null, PropertyType::REFERENCE),
-            array($datetimeLong, PropertyType::DATE, null, PropertyType::URI),
-            array($datetimeLong, PropertyType::DATE, '123', PropertyType::DECIMAL),
+            // Date to...
+            [$datetimeLong, PropertyType::DATE, $datetimeLong->format('Y-m-d\TH:i:s.') . substr($datetimeLong->format('u'), 0, 3) . $datetimeLong->format('P'), PropertyType::STRING],
+            [$datetimeLong, PropertyType::DATE, 123, PropertyType::LONG],
+            [$datetimeLong, PropertyType::DATE, 123.0, PropertyType::DOUBLE],
+            [$datetimeLong, PropertyType::DATE, $datetimeLong, PropertyType::DATE],
+            [$datetimeLong, PropertyType::DATE, true, PropertyType::BOOLEAN],
+            [$datetimeLong, PropertyType::DATE, null, PropertyType::NAME],
+            [$datetimeLong, PropertyType::DATE, null, PropertyType::PATH],
+            [$datetimeLong, PropertyType::DATE, null, PropertyType::REFERENCE],
+            [$datetimeLong, PropertyType::DATE, null, PropertyType::URI],
+            [$datetimeLong, PropertyType::DATE, '123', PropertyType::DECIMAL],
 
-            // boolean to...
-            array(true, PropertyType::BOOLEAN, '1', PropertyType::STRING),
-            array(false, PropertyType::BOOLEAN, '', PropertyType::STRING),
-            array(true, PropertyType::BOOLEAN, null, PropertyType::DATE),
-            array(true, PropertyType::BOOLEAN, 1, PropertyType::LONG),
-            array(true, PropertyType::BOOLEAN, 1.0, PropertyType::DOUBLE),
-            array(true, PropertyType::BOOLEAN, true, PropertyType::BOOLEAN),
-            array(true, PropertyType::BOOLEAN, null, PropertyType::NAME),
-            array(true, PropertyType::BOOLEAN, null, PropertyType::PATH),
-            array(true, PropertyType::BOOLEAN, null, PropertyType::REFERENCE),
-            array(true, PropertyType::BOOLEAN, null, PropertyType::URI),
-            array(true, PropertyType::BOOLEAN, '1', PropertyType::DECIMAL),
-            array(false, PropertyType::BOOLEAN, '', PropertyType::DECIMAL),
+            // Boolean to...
+            [true, PropertyType::BOOLEAN, '1', PropertyType::STRING],
+            [false, PropertyType::BOOLEAN, '', PropertyType::STRING],
+            [true, PropertyType::BOOLEAN, null, PropertyType::DATE],
+            [true, PropertyType::BOOLEAN, 1, PropertyType::LONG],
+            [true, PropertyType::BOOLEAN, 1.0, PropertyType::DOUBLE],
+            [true, PropertyType::BOOLEAN, true, PropertyType::BOOLEAN],
+            [true, PropertyType::BOOLEAN, null, PropertyType::NAME],
+            [true, PropertyType::BOOLEAN, null, PropertyType::PATH],
+            [true, PropertyType::BOOLEAN, null, PropertyType::REFERENCE],
+            [true, PropertyType::BOOLEAN, null, PropertyType::URI],
+            [true, PropertyType::BOOLEAN, '1', PropertyType::DECIMAL],
+            [false, PropertyType::BOOLEAN, '', PropertyType::DECIMAL],
 
-            // name to...
-            array('name', PropertyType::NAME, 'name', PropertyType::STRING),
-            array('name', PropertyType::NAME, null, PropertyType::DATE),
-            array('name', PropertyType::NAME, null, PropertyType::LONG),
-            array('name', PropertyType::NAME, null, PropertyType::DOUBLE),
-            array('name', PropertyType::NAME, null, PropertyType::BOOLEAN),
-            array('name', PropertyType::NAME, 'name', PropertyType::NAME),
-            array('name', PropertyType::NAME, 'name', PropertyType::PATH),
-            array('name', PropertyType::NAME, null, PropertyType::REFERENCE),
-            array('name', PropertyType::NAME, '../name', PropertyType::URI),
-            array('näme', PropertyType::NAME, '../n%C3%A4me', PropertyType::URI),
-            array('name', PropertyType::NAME, null, PropertyType::DECIMAL),
+            // Name to...
+            ['name', PropertyType::NAME, 'name', PropertyType::STRING],
+            ['name', PropertyType::NAME, null, PropertyType::DATE],
+            ['name', PropertyType::NAME, null, PropertyType::LONG],
+            ['name', PropertyType::NAME, null, PropertyType::DOUBLE],
+            ['name', PropertyType::NAME, null, PropertyType::BOOLEAN],
+            ['name', PropertyType::NAME, 'name', PropertyType::NAME],
+            ['name', PropertyType::NAME, 'name', PropertyType::PATH],
+            ['name', PropertyType::NAME, null, PropertyType::REFERENCE],
+            ['name', PropertyType::NAME, '../name', PropertyType::URI],
+            ['näme', PropertyType::NAME, '../n%C3%A4me', PropertyType::URI],
+            ['name', PropertyType::NAME, null, PropertyType::DECIMAL],
 
-            // path to...
-            array('../test/path', PropertyType::PATH, '../test/path', PropertyType::STRING),
-            array('../test/path', PropertyType::PATH, null, PropertyType::DATE),
-            array('../test/path', PropertyType::PATH, null, PropertyType::LONG),
-            array('../test/path', PropertyType::PATH, null, PropertyType::DOUBLE),
-            array('../test/path', PropertyType::PATH, null, PropertyType::BOOLEAN),
-            // TODO: fix array('../test/path', PropertyType::PATH, null, PropertyType::NAME),
-            // TODO: fix array('./path', PropertyType::PATH, 'path', PropertyType::NAME),
-            array('../test/path', PropertyType::PATH, '../test/path', PropertyType::PATH),
-            array('../test/path', PropertyType::PATH, null, PropertyType::REFERENCE),
-            array('../test/path', PropertyType::PATH, '../test/path', PropertyType::URI),
-            array('../test/päth', PropertyType::PATH, '../test/p%C3%A4th', PropertyType::URI),
-            array('test', PropertyType::PATH, './test', PropertyType::URI),
-            array('../test/path', PropertyType::PATH, null, PropertyType::DECIMAL),
+            // Path to...
+            ['../test/path', PropertyType::PATH, '../test/path', PropertyType::STRING],
+            ['../test/path', PropertyType::PATH, null, PropertyType::DATE],
+            ['../test/path', PropertyType::PATH, null, PropertyType::LONG],
+            ['../test/path', PropertyType::PATH, null, PropertyType::DOUBLE],
+            ['../test/path', PropertyType::PATH, null, PropertyType::BOOLEAN],
+            // TODO: fix ['../test/path', PropertyType::PATH, null, PropertyType::NAME],
+            // TODO: fix ['./path', PropertyType::PATH, 'path', PropertyType::NAME],
+            ['../test/path', PropertyType::PATH, '../test/path', PropertyType::PATH],
+            ['../test/path', PropertyType::PATH, null, PropertyType::REFERENCE],
+            ['../test/path', PropertyType::PATH, '../test/path', PropertyType::URI],
+            ['../test/päth', PropertyType::PATH, '../test/p%C3%A4th', PropertyType::URI],
+            ['test', PropertyType::PATH, './test', PropertyType::URI],
+            ['../test/path', PropertyType::PATH, null, PropertyType::DECIMAL],
 
-            // reference to...
-            array('38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE, '38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::STRING),
-            array($nodemock, PropertyType::REFERENCE, '38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::STRING),
-            array('38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE, '38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE),
-            array($nodemock, PropertyType::REFERENCE, '38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE),
-            array('38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE, null, PropertyType::DATE),
-            array($nodemock, PropertyType::REFERENCE, null, PropertyType::DATE),
-            array('38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE, null, PropertyType::LONG),
-            array($nodemock, PropertyType::REFERENCE, null, PropertyType::LONG),
-            array('38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE, null, PropertyType::DOUBLE),
-            array($nodemock, PropertyType::REFERENCE, null, PropertyType::DOUBLE),
-            array('38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE, null, PropertyType::BOOLEAN),
-            array($nodemock, PropertyType::REFERENCE, null, PropertyType::BOOLEAN),
-            array('38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE, null, PropertyType::NAME),
-            array($nodemock, PropertyType::REFERENCE, null, PropertyType::NAME),
-            array('38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE, null, PropertyType::PATH),
-            array($nodemock, PropertyType::REFERENCE, null, PropertyType::PATH),
-            array('38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE, null, PropertyType::URI),
-            array($nodemock, PropertyType::REFERENCE, null, PropertyType::URI),
-            array('38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE, '38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE),
-            array('38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE, null, PropertyType::DECIMAL),
-            array($nodemock, PropertyType::REFERENCE, null, PropertyType::DECIMAL),
+            // Reference to...
+            ['38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE, '38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::STRING],
+            [$nodeMock, PropertyType::REFERENCE, '38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::STRING],
+            ['38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE, '38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE],
+            [$nodeMock, PropertyType::REFERENCE, '38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE],
+            ['38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE, null, PropertyType::DATE],
+            [$nodeMock, PropertyType::REFERENCE, null, PropertyType::DATE],
+            ['38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE, null, PropertyType::LONG],
+            [$nodeMock, PropertyType::REFERENCE, null, PropertyType::LONG],
+            ['38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE, null, PropertyType::DOUBLE],
+            [$nodeMock, PropertyType::REFERENCE, null, PropertyType::DOUBLE],
+            ['38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE, null, PropertyType::BOOLEAN],
+            [$nodeMock, PropertyType::REFERENCE, null, PropertyType::BOOLEAN],
+            ['38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE, null, PropertyType::NAME],
+            [$nodeMock, PropertyType::REFERENCE, null, PropertyType::NAME],
+            ['38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE, null, PropertyType::PATH],
+            [$nodeMock, PropertyType::REFERENCE, null, PropertyType::PATH],
+            ['38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE, null, PropertyType::URI],
+            [$nodeMock, PropertyType::REFERENCE, null, PropertyType::URI],
+            ['38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE, '38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE],
+            ['38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE, null, PropertyType::DECIMAL],
+            [$nodeMock, PropertyType::REFERENCE, null, PropertyType::DECIMAL],
 
-            array($this, PropertyType::REFERENCE, null, PropertyType::STRING),
-            array($this, PropertyType::REFERENCE, null, PropertyType::BINARY),
-            array($this, PropertyType::REFERENCE, null, PropertyType::DATE),
-            array($this, PropertyType::REFERENCE, null, PropertyType::LONG),
-            array($this, PropertyType::REFERENCE, null, PropertyType::DOUBLE),
-            array($this, PropertyType::REFERENCE, null, PropertyType::BOOLEAN),
-            array($this, PropertyType::REFERENCE, null, PropertyType::NAME),
-            array($this, PropertyType::REFERENCE, null, PropertyType::PATH),
-            array($this, PropertyType::REFERENCE, null, PropertyType::URI),
-            array($this, PropertyType::REFERENCE, null, PropertyType::DECIMAL),
+            [$this, PropertyType::REFERENCE, null, PropertyType::STRING],
+            [$this, PropertyType::REFERENCE, null, PropertyType::BINARY],
+            [$this, PropertyType::REFERENCE, null, PropertyType::DATE],
+            [$this, PropertyType::REFERENCE, null, PropertyType::LONG],
+            [$this, PropertyType::REFERENCE, null, PropertyType::DOUBLE],
+            [$this, PropertyType::REFERENCE, null, PropertyType::BOOLEAN],
+            [$this, PropertyType::REFERENCE, null, PropertyType::NAME],
+            [$this, PropertyType::REFERENCE, null, PropertyType::PATH],
+            [$this, PropertyType::REFERENCE, null, PropertyType::URI],
+            [$this, PropertyType::REFERENCE, null, PropertyType::DECIMAL],
 
-            // weak to...
-            array('38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::WEAKREFERENCE, '38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::STRING),
-            array($nodemock, PropertyType::WEAKREFERENCE, '38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::STRING),
-            array('38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::WEAKREFERENCE, '38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE),
-            array($nodemock, PropertyType::WEAKREFERENCE, '38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE),
-            array('38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::WEAKREFERENCE, null, PropertyType::DATE),
-            array($nodemock, PropertyType::WEAKREFERENCE, null, PropertyType::DATE),
-            array('38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::WEAKREFERENCE, null, PropertyType::LONG),
-            array($nodemock, PropertyType::WEAKREFERENCE, null, PropertyType::LONG),
-            array('38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::WEAKREFERENCE, null, PropertyType::DOUBLE),
-            array($nodemock, PropertyType::WEAKREFERENCE, null, PropertyType::DOUBLE),
-            array('38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::WEAKREFERENCE, null, PropertyType::BOOLEAN),
-            array($nodemock, PropertyType::WEAKREFERENCE, null, PropertyType::BOOLEAN),
-            array('38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::WEAKREFERENCE, null, PropertyType::NAME),
-            array($nodemock, PropertyType::WEAKREFERENCE, null, PropertyType::NAME),
-            array('38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::WEAKREFERENCE, null, PropertyType::PATH),
-            array($nodemock, PropertyType::WEAKREFERENCE, null, PropertyType::PATH),
-            array('38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::WEAKREFERENCE, null, PropertyType::URI),
-            array($nodemock, PropertyType::WEAKREFERENCE, null, PropertyType::URI),
-            array('38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::WEAKREFERENCE, '38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE),
-            array('38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::WEAKREFERENCE, null, PropertyType::DECIMAL),
-            array($nodemock, PropertyType::WEAKREFERENCE, null, PropertyType::DECIMAL),
+            // Weak to...
+            ['38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::WEAKREFERENCE, '38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::STRING],
+            [$nodeMock, PropertyType::WEAKREFERENCE, '38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::STRING],
+            ['38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::WEAKREFERENCE, '38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE],
+            [$nodeMock, PropertyType::WEAKREFERENCE, '38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE],
+            ['38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::WEAKREFERENCE, null, PropertyType::DATE],
+            [$nodeMock, PropertyType::WEAKREFERENCE, null, PropertyType::DATE],
+            ['38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::WEAKREFERENCE, null, PropertyType::LONG],
+            [$nodeMock, PropertyType::WEAKREFERENCE, null, PropertyType::LONG],
+            ['38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::WEAKREFERENCE, null, PropertyType::DOUBLE],
+            [$nodeMock, PropertyType::WEAKREFERENCE, null, PropertyType::DOUBLE],
+            ['38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::WEAKREFERENCE, null, PropertyType::BOOLEAN],
+            [$nodeMock, PropertyType::WEAKREFERENCE, null, PropertyType::BOOLEAN],
+            ['38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::WEAKREFERENCE, null, PropertyType::NAME],
+            [$nodeMock, PropertyType::WEAKREFERENCE, null, PropertyType::NAME],
+            ['38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::WEAKREFERENCE, null, PropertyType::PATH],
+            [$nodeMock, PropertyType::WEAKREFERENCE, null, PropertyType::PATH],
+            ['38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::WEAKREFERENCE, null, PropertyType::URI],
+            [$nodeMock, PropertyType::WEAKREFERENCE, null, PropertyType::URI],
+            ['38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::WEAKREFERENCE, '38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::REFERENCE],
+            ['38b7cf18-c417-477a-af0b-c1e92a290c9a', PropertyType::WEAKREFERENCE, null, PropertyType::DECIMAL],
+            [$nodeMock, PropertyType::WEAKREFERENCE, null, PropertyType::DECIMAL],
 
             // uri to...
-            array('http://phpcr.githbub.com/doc/html', PropertyType::URI, 'http://phpcr.githbub.com/doc/html', PropertyType::STRING),
-            array('http://phpcr.githbub.com/doc/html', PropertyType::URI, null, PropertyType::DATE),
-            array('http://phpcr.githbub.com/doc/html', PropertyType::URI, null, PropertyType::LONG),
-            array('http://phpcr.githbub.com/doc/html', PropertyType::URI, null, PropertyType::DOUBLE),
-            array('http://phpcr.githbub.com/doc/html', PropertyType::URI, null, PropertyType::BOOLEAN),
-            // TODO: fix array('http://phpcr.githbub.com/doc/html', PropertyType::URI, null, PropertyType::NAME),
-            // TODO: fix array('http://phpcr.githbub.com/doc/html', PropertyType::URI, null, PropertyType::PATH),
-            array('http://phpcr.githbub.com/doc/html', PropertyType::URI, null, PropertyType::REFERENCE),
-            array('http://phpcr.githbub.com/doc/html', PropertyType::URI, 'http://phpcr.githbub.com/doc/html', PropertyType::URI),
-            array('http://phpcr.githbub.com/doc/html', PropertyType::URI, null, PropertyType::DECIMAL),
+            ['http://phpcr.githbub.com/doc/html', PropertyType::URI, 'http://phpcr.githbub.com/doc/html', PropertyType::STRING],
+            ['http://phpcr.githbub.com/doc/html', PropertyType::URI, null, PropertyType::DATE],
+            ['http://phpcr.githbub.com/doc/html', PropertyType::URI, null, PropertyType::LONG],
+            ['http://phpcr.githbub.com/doc/html', PropertyType::URI, null, PropertyType::DOUBLE],
+            ['http://phpcr.githbub.com/doc/html', PropertyType::URI, null, PropertyType::BOOLEAN],
+            // TODO: fix ['http://phpcr.githbub.com/doc/html', PropertyType::URI, null, PropertyType::NAME],
+            // TODO: fix ['http://phpcr.githbub.com/doc/html', PropertyType::URI, null, PropertyType::PATH],
+            ['http://phpcr.githbub.com/doc/html', PropertyType::URI, null, PropertyType::REFERENCE],
+            ['http://phpcr.githbub.com/doc/html', PropertyType::URI, 'http://phpcr.githbub.com/doc/html', PropertyType::URI],
+            ['http://phpcr.githbub.com/doc/html', PropertyType::URI, null, PropertyType::DECIMAL],
 
             // decimal to...
-            array('123.4', PropertyType::DECIMAL, '123.4', PropertyType::STRING),
-            array('123.4', PropertyType::DECIMAL, $datetimeLong, PropertyType::DATE),
-            array('123.4', PropertyType::DECIMAL, 123, PropertyType::LONG),
-            array('123.4', PropertyType::DECIMAL, 123.4, PropertyType::DOUBLE),
-            array('123.4', PropertyType::DECIMAL, true, PropertyType::BOOLEAN),
-            array('0', PropertyType::DECIMAL, false, PropertyType::BOOLEAN),
-            array('123.4', PropertyType::DECIMAL, null, PropertyType::NAME),
-            array('123.4', PropertyType::DECIMAL, null, PropertyType::PATH),
-            array('123.4', PropertyType::DECIMAL, null, PropertyType::URI),
-            array('123.4', PropertyType::DECIMAL, null, PropertyType::REFERENCE),
-            array('123.4', PropertyType::DECIMAL, '123.4', PropertyType::DECIMAL),
-        );
+            ['123.4', PropertyType::DECIMAL, '123.4', PropertyType::STRING],
+            ['123.4', PropertyType::DECIMAL, $datetimeLong, PropertyType::DATE],
+            ['123.4', PropertyType::DECIMAL, 123, PropertyType::LONG],
+            ['123.4', PropertyType::DECIMAL, 123.4, PropertyType::DOUBLE],
+            ['123.4', PropertyType::DECIMAL, true, PropertyType::BOOLEAN],
+            ['0', PropertyType::DECIMAL, false, PropertyType::BOOLEAN],
+            ['123.4', PropertyType::DECIMAL, null, PropertyType::NAME],
+            ['123.4', PropertyType::DECIMAL, null, PropertyType::PATH],
+            ['123.4', PropertyType::DECIMAL, null, PropertyType::URI],
+            ['123.4', PropertyType::DECIMAL, null, PropertyType::REFERENCE],
+            ['123.4', PropertyType::DECIMAL, '123.4', PropertyType::DECIMAL],
+        ];
     }
 
     /**
      * Skip binary target as its a special case
      *
-     * @param int $srctype PropertyType constant to convert from
-     * @param $validtargets array map of target type => value | null for exception
+     * @param mixed $value
+     * @param int $srcType PropertyType constant to convert from
+     * @param $expected
+     * @param $targetType
      *
      * @dataProvider dataConversionMatrix
      */
-    public function testConvertType($value, $srctype, $expected, $targettype)
+    public function testConvertType($value, $srcType, $expected, $targetType)
     {
         if (null === $expected) {
             try {
-                $this->valueConverter->convertType($value, $targettype, $srctype);
-                $this->fail('Excpected that this conversion would throw an exception');
-            } catch (\PHPCR\ValueFormatException $e) {
+                $this->valueConverter->convertType($value, $targetType, $srcType);
+                $this->fail('Expected that this conversion would throw an exception');
+            } catch (ValueFormatException $e) {
                 // expected
                 $this->assertTrue(true); // make it assert something
             }
         } else {
-            if ($expected instanceof \DateTime) {
-                $result = $this->valueConverter->convertType($value, $targettype, $srctype);
-                $this->assertInstanceOf('DateTime', $result);
+            if ($expected instanceof DateTime) {
+                $result = $this->valueConverter->convertType($value, $targetType, $srcType);
+                $this->assertInstanceOf(DateTime::class, $result);
                 $this->assertEquals($expected->getTimestamp(), $result->getTimestamp());
             } else {
-                $this->assertSame($expected, $this->valueConverter->convertType($value, $targettype, $srctype));
+                $this->assertSame($expected, $this->valueConverter->convertType($value, $targetType, $srcType));
             }
         }
     }
@@ -303,11 +313,11 @@ class ValueConverterTest extends \PHPUnit_Framework_TestCase
         $string = stream_get_contents($stream);
         $this->assertEquals('test string', $string);
 
-        $date = new \DateTime('20.12.2012');
+        $date = new DateTime('20.12.2012');
         $stream = $this->valueConverter->convertType($date, PropertyType::BINARY);
         $this->assertInternalType('resource', $stream);
         $string = stream_get_contents($stream);
-        $readDate = new \DateTime($string);
+        $readDate = new DateTime($string);
         $this->assertEquals($date->getTimestamp(), $readDate->getTimestamp());
 
         $stream = fopen('php://memory', '+rw');
@@ -322,121 +332,119 @@ class ValueConverterTest extends \PHPUnit_Framework_TestCase
 
     public function testConvertTypeArray()
     {
-        $result = $this->valueConverter->convertType(array('2012-01-10', '2012-02-12'),
+        $result = $this->valueConverter->convertType(['2012-01-10', '2012-02-12'],
             PropertyType::DATE,
             PropertyType::STRING);
         $this->assertInternalType('array', $result);
         $this->assertCount(2, $result);
 
-        $this->assertInstanceOf('DateTime', $result[0]);
-        $this->assertInstanceOf('DateTime', $result[1]);
+        $this->assertInstanceOf(DateTime::class, $result[0]);
+        $this->assertInstanceOf(DateTime::class, $result[1]);
 
         $this->assertEquals('2012-01-10', $result[0]->format('Y-m-d'));
         $this->assertEquals('2012-02-12', $result[1]->format('Y-m-d'));
 
-        $result = $this->valueConverter->convertType(array(), PropertyType::STRING, PropertyType::NAME);
-        $this->assertEquals(array(), $result);
+        $result = $this->valueConverter->convertType([], PropertyType::STRING, PropertyType::NAME);
+        $this->assertEquals([], $result);
     }
 
     public function testConvertTypeAutodetect()
     {
-        $date = new \DateTime('2012-10-10');
+        $date = new DateTime('2012-10-10');
         $result = $this->valueConverter->convertType($date, PropertyType::STRING);
-        $result = new \DateTime($result);
+        $result = new DateTime($result);
         $this->assertEquals($date->getTimestamp(), $result->getTimestamp());
 
         $result = $this->valueConverter->convertType('2012-03-13T21:00:55.000+01:00', PropertyType::DATE);
-        $this->assertInstanceOf('DateTime', $result);
+        $this->assertInstanceOf(DateTime::class, $result);
         $this->assertEquals(1331668855, $result->getTimestamp());
     }
 
-    /**
-     * @expectedException \PHPCR\ValueFormatException
-     */
     public function testConvertTypeArrayInvalid()
     {
-        $this->valueConverter->convertType(array('a', 'b', 'c'), PropertyType::NAME, PropertyType::REFERENCE);
+        $this->expectException(ValueFormatException::class);
+
+        $this->valueConverter->convertType(['a', 'b', 'c'], PropertyType::NAME, PropertyType::REFERENCE);
     }
 
-    /**
-     * @expectedException \PHPCR\ValueFormatException
-     */
     public function testConvertInvalidString()
     {
+        $this->expectException(ValueFormatException::class);
+
         $this->valueConverter->convertType($this, PropertyType::STRING);
     }
-    /**
-     * @expectedException \PHPCR\ValueFormatException
-     */
+
     public function testConvertInvalidBinary()
     {
+        $this->expectException(ValueFormatException::class);
+
         $this->valueConverter->convertType($this, PropertyType::BINARY);
     }
-    /**
-     * @expectedException \PHPCR\ValueFormatException
-     */
+
     public function testConvertInvalidDate()
     {
+        $this->expectException(ValueFormatException::class);
+
         $this->valueConverter->convertType($this, PropertyType::DATE);
     }
 
-    /**
-     * @expectedException \PHPCR\ValueFormatException
-     */
     public function testConvertNewNode()
     {
-        $nodemock = $this->getMock('PHPCR\Tests\Stubs\MockNode');
-        $nodemock
+        $this->expectException(ValueFormatException::class);
+
+        $nodeMock = $this->createMock(MockNode::class);
+        $nodeMock
             ->expects($this->never())
             ->method('isNew')
             ->will($this->returnValue(true))
         ;
-        $this->valueConverter->convertType($nodemock, PropertyType::STRING);
+        $this->valueConverter->convertType($nodeMock, PropertyType::STRING);
     }
-    /**
-     * @expectedException \PHPCR\ValueFormatException
-     */
-    public function testConvertNonrefNode()
+
+    public function testConvertNonRefNode()
     {
-        $nodemock = $this->getMock('PHPCR\Tests\Stubs\MockNode');
-        $nodemock
+        $this->expectException(ValueFormatException::class);
+
+        $nodeMock = $this->createMock(MockNode::class);
+        $nodeMock
             ->expects($this->never())
             ->method('isNew')
             ->will($this->returnValue(false))
         ;
-        $nodemock
+        $nodeMock
             ->expects($this->once())
             ->method('isNodeType')
             ->with('mix:referenceable')
             ->will($this->returnValue(false))
         ;
-        $this->valueConverter->convertType($nodemock, PropertyType::STRING);
+        $this->valueConverter->convertType($nodeMock, PropertyType::STRING);
     }
 
     public function dataDateTargetType()
     {
-        return array(
-            array(PropertyType::STRING),
-            array(PropertyType::LONG),
-            array(PropertyType::DOUBLE),
-        );
+        return [
+            [PropertyType::STRING],
+            [PropertyType::LONG],
+            [PropertyType::DOUBLE],
+        ];
     }
 
     /**
      * Check if the util will survive a broken implementation
-     * @expectedException \PHPCR\RepositoryException
+     *
      * @dataProvider dataDateTargetType
      */
     public function testConvertInvalidDateValue($targettype)
     {
+        $this->expectException(RepositoryException::class);
+
         $this->valueConverter->convertType('', $targettype, PropertyType::DATE);
     }
 
-    /**
-     * @expectedException \PHPCR\ValueFormatException
-     */
     public function testConvertTypeInvalidTarget()
     {
+        $this->expectException(ValueFormatException::class);
+
         $this->valueConverter->convertType('test', PropertyType::UNDEFINED);
     }
 }


### PR DESCRIPTION
was added PHPUnit to dev-dependencies

tests were updated to remove deprecations (please double-check it!!!)

+ BONUS: was added PHPStan to dev-dependencies it can help us to make better code and in future we can run it before tests to analyze code :)

And finally joke: I think that CndParserTest is here (in this package) so that i made this refactoring I wan't to mark it as skipped in the end but I was very surprised :-D :-D