### PR TITLE
Use PSR-1 for PHPUnit TestCase

### DIFF
--- a/tests/PHPCR/Tests/Util/CND/Reader/BufferReaderTest.php
+++ b/tests/PHPCR/Tests/Util/CND/Reader/BufferReaderTest.php
@@ -3,9 +3,9 @@
 namespace PHPCR\Tests\Util\CND\Reader;
 
 use PHPCR\Util\CND\Reader\BufferReader;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class BufferReaderTest extends PHPUnit_Framework_TestCase
+class BufferReaderTest extends TestCase
 {
     public function test__construct()
     {

--- a/tests/PHPCR/Tests/Util/CND/Reader/FileReaderTest.php
+++ b/tests/PHPCR/Tests/Util/CND/Reader/FileReaderTest.php
@@ -4,9 +4,9 @@ namespace PHPCR\Tests\Util\CND\Reader;
 
 use InvalidArgumentException;
 use PHPCR\Util\CND\Reader\FileReader;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class FileReaderTest extends PHPUnit_Framework_TestCase
+class FileReaderTest extends TestCase
 {
     /**
      * @var string

--- a/tests/PHPCR/Tests/Util/CND/Scanner/GenericScannerTest.php
+++ b/tests/PHPCR/Tests/Util/CND/Scanner/GenericScannerTest.php
@@ -9,11 +9,11 @@ use PHPCR\Util\CND\Scanner\GenericToken as Token;
 use PHPCR\Util\CND\Scanner\TokenQueue;
 use PHPCR\Util\CND\Scanner\TokenFilter;
 use PHPCR\Util\CND\Scanner\Context\DefaultScannerContext;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Test;
 use TestClass;
 
-class GenericScannerTest extends PHPUnit_Framework_TestCase
+class GenericScannerTest extends TestCase
 {
     protected $expectedTokens = [
 

--- a/tests/PHPCR/Tests/Util/CND/Scanner/TokenQueueTest.php
+++ b/tests/PHPCR/Tests/Util/CND/Scanner/TokenQueueTest.php
@@ -4,9 +4,9 @@ namespace PHPCR\Tests\Util\CND\Scanner;
 
 use PHPCR\Util\CND\Scanner\Token;
 use PHPCR\Util\CND\Scanner\TokenQueue;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class TokenQueueTest extends PHPUnit_Framework_TestCase
+class TokenQueueTest extends TestCase
 {
     /**
      * @var Token

--- a/tests/PHPCR/Tests/Util/CND/Scanner/TokenTest.php
+++ b/tests/PHPCR/Tests/Util/CND/Scanner/TokenTest.php
@@ -3,9 +3,9 @@
 namespace PHPCR\Tests\Util\CND\Scanner;
 
 use PHPCR\Util\CND\Scanner\Token;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class TokenTest extends PHPUnit_Framework_TestCase
+class TokenTest extends TestCase
 {
     /**
      * @var Token

--- a/tests/PHPCR/Tests/Util/Console/Command/BaseCommandTest.php
+++ b/tests/PHPCR/Tests/Util/Console/Command/BaseCommandTest.php
@@ -9,7 +9,7 @@ use PHPCR\RepositoryInterface;
 use PHPCR\Tests\Stubs\MockNode;
 use PHPCR\Tests\Stubs\MockRow;
 use PHPUnit_Framework_MockObject_MockObject;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Console\Helper\HelperSet;
@@ -22,7 +22,7 @@ require_once __DIR__.'/../../../Stubs/MockNode.php';
 require_once __DIR__.'/../../../Stubs/MockNodeTypeManager.php';
 require_once __DIR__.'/../../../Stubs/MockRow.php';
 
-abstract class BaseCommandTest extends PHPUnit_Framework_TestCase
+abstract class BaseCommandTest extends TestCase
 {
     /**
      * @var SessionInterface|PHPUnit_Framework_MockObject_MockObject

--- a/tests/PHPCR/Tests/Util/Console/Helper/PhpcrConsoleDumperHelperTest.php
+++ b/tests/PHPCR/Tests/Util/Console/Helper/PhpcrConsoleDumperHelperTest.php
@@ -4,8 +4,9 @@ use PHPCR\Util\Console\Helper\PhpcrConsoleDumperHelper;
 use PHPCR\Util\Console\Helper\TreeDumper\ConsoleDumperPropertyVisitor;
 use PHPCR\Util\TreeWalker;
 use Symfony\Component\Console\Output\OutputInterface;
+use PHPUnit\Framework\TestCase;
 
-class PhpcrConsoleDumperHelperTest extends PHPUnit_Framework_TestCase
+class PhpcrConsoleDumperHelperTest extends TestCase
 {
     private $outputMock;
     /**

--- a/tests/PHPCR/Tests/Util/NodeHelperTest.php
+++ b/tests/PHPCR/Tests/Util/NodeHelperTest.php
@@ -5,11 +5,11 @@ namespace PHPCR\Tests\Util;
 use PHPCR\Tests\Stubs\MockNode;
 use PHPCR\Util\NodeHelper;
 use PHPUnit_Framework_MockObject_MockObject;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 require_once __DIR__.'/../Stubs/MockNode.php';
 
-class NodeHelperTest extends PHPUnit_Framework_TestCase
+class NodeHelperTest extends TestCase
 {
     /**
      * @var array

--- a/tests/PHPCR/Tests/Util/PathHelperTest.php
+++ b/tests/PHPCR/Tests/Util/PathHelperTest.php
@@ -6,8 +6,9 @@ use PHPCR\NamespaceException;
 use PHPCR\RepositoryException;
 use PHPCR\Util\PathHelper;
 use stdClass;
+use PHPUnit\Framework\TestCase;
 
-class PathHelperTest extends \PHPUnit_Framework_TestCase
+class PathHelperTest extends TestCase
 {
     // assertValidPath tests
 

--- a/tests/PHPCR/Tests/Util/QOM/BaseSqlGeneratorTest.php
+++ b/tests/PHPCR/Tests/Util/QOM/BaseSqlGeneratorTest.php
@@ -2,9 +2,9 @@
 
 namespace PHPCR\Tests\Util\QOM;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-abstract class BaseSqlGeneratorTest extends PHPUnit_Framework_TestCase
+abstract class BaseSqlGeneratorTest extends TestCase
 {
     public function testNot()
     {

--- a/tests/PHPCR/Tests/Util/QOM/QueryBuilderTest.php
+++ b/tests/PHPCR/Tests/Util/QOM/QueryBuilderTest.php
@@ -12,10 +12,10 @@ use PHPCR\Query\QOM\SameNodeJoinConditionInterface;
 use PHPCR\Query\QOM\SourceInterface;
 use PHPCR\Util\QOM\QueryBuilder;
 use PHPUnit_Framework_MockObject_MockObject;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-class QueryBuilderTest extends PHPUnit_Framework_TestCase
+class QueryBuilderTest extends TestCase
 {
     /**
      * @var PHPUnit_Framework_MockObject_MockObject|QueryObjectModelFactoryInterface

--- a/tests/PHPCR/Tests/Util/QOM/Sql1GeneratorTest.php
+++ b/tests/PHPCR/Tests/Util/QOM/Sql1GeneratorTest.php
@@ -5,9 +5,9 @@ namespace PHPCR\Tests\Util\QOM;
 use DateTime;
 use PHPCR\Util\QOM\Sql1Generator;
 use PHPCR\Util\ValueConverter;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class Sql1GeneratorTest extends PHPUnit_Framework_TestCase
+class Sql1GeneratorTest extends TestCase
 {
     /**
      * @var Sql1Generator

--- a/tests/PHPCR/Tests/Util/QOM/Sql2ToQomQueryConverterTest.php
+++ b/tests/PHPCR/Tests/Util/QOM/Sql2ToQomQueryConverterTest.php
@@ -6,9 +6,9 @@ use PHPCR\Query\InvalidQueryException;
 use PHPCR\Query\QOM\QueryObjectModelFactoryInterface;
 use PHPCR\Util\QOM\Sql2ToQomQueryConverter;
 use PHPCR\Util\ValueConverter;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class Sql2ToQomQueryConverterTest extends PHPUnit_Framework_TestCase
+class Sql2ToQomQueryConverterTest extends TestCase
 {
     /**
      * @var QueryObjectModelFactoryInterface

--- a/tests/PHPCR/Tests/Util/TraversingItemVisitorTest.php
+++ b/tests/PHPCR/Tests/Util/TraversingItemVisitorTest.php
@@ -2,9 +2,9 @@
 
 namespace PHPCR\Tests\Util;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class TraversingItemVisitorTest extends PHPUnit_Framework_TestCase
+class TraversingItemVisitorTest extends TestCase
 {
     public function testVisitor()
     {

--- a/tests/PHPCR/Tests/Util/UUIDHelperTest.php
+++ b/tests/PHPCR/Tests/Util/UUIDHelperTest.php
@@ -3,9 +3,9 @@
 namespace PHPCR\Tests\Util;
 
 use PHPCR\Util\UUIDHelper;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class UUIDHelperTest extends PHPUnit_Framework_TestCase
+class UUIDHelperTest extends TestCase
 {
     public function testGenerateUUID()
     {

--- a/tests/PHPCR/Tests/Util/ValueConverterTest.php
+++ b/tests/PHPCR/Tests/Util/ValueConverterTest.php
@@ -7,14 +7,14 @@ use PHPCR\RepositoryException;
 use PHPCR\Tests\Stubs\MockNode;
 use PHPCR\Util\ValueConverter;
 use PHPCR\ValueFormatException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 require_once __DIR__.'/../Stubs/MockNode.php';
 
 /**
  * A test for the PHPCR\PropertyType class
  */
-class ValueConverterTest extends PHPUnit_Framework_TestCase
+class ValueConverterTest extends TestCase
 {
     /**
      * @var ValueConverter


### PR DESCRIPTION
Use [PSR-1](http://www.php-fig.org/psr/psr-1/#namespace-and-class-names) while extending PHPUnit TestCase class. This will help us when to migrate to PHPUnit 6, that [no longer support snake case namespaces](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).