### PR TITLE
allow symfony 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
 
@@ -13,7 +11,7 @@ sudo: false
 
 matrix:
   include:
-    - php: 5.6
+    - php: 7.1
       env: PACKAGE_VERSION=low
     - php: hhvm
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: php
 
 php:
+  - 5.6
+  - 7.0
   - 7.1
   - 7.2
 
@@ -11,10 +13,8 @@ sudo: false
 
 matrix:
   include:
-    - php: 7.1
+    - php: 5.6
       env: PACKAGE_VERSION=low
-    - php: hhvm
-      dist: trusty
 
 before_script:
   - composer selfupdate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+* **2017-11-18**: Removed hhvm test
+
 1.2.7
 -----
 

--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,9 @@
         }
     ],
     "require": {
-        "php": "^5.6|^7.0",
+        "php": "^7.1",
         "phpcr/phpcr": "~2.1.0",
-        "symfony/console": "~2.3|~3.0"
+        "symfony/console": "~2.3|~3.0|^4.0"
     },
     "require-dev": {
         "ramsey/uuid": "^3.5",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^5.6|^7.0",
         "phpcr/phpcr": "~2.1.0",
         "symfony/console": "~2.3|~3.0|^4.0"
     },


### PR DESCRIPTION
This should allow symfony 4.0 on dependant repositories.
#SymfonyConHackday2017