### PR TITLE
Added option to control the uuid-behavior

### DIFF
--- a/src/PHPCR/Util/Console/Command/WorkspaceImportCommand.php
+++ b/src/PHPCR/Util/Console/Command/WorkspaceImportCommand.php
@@ -46,6 +46,15 @@ and XML attributes into properties.
 
 If the <info>parentpath</info> option is set, the document is imported to that
 path. Otherwise the document is imported at the repository root.
+
+The optional <info>uuid-behavior</info> option describes how uuids should be
+handled. Following options are available:
+
+* <info>new</info> recreate the uuid foreach node
+* <info>remove</info> remove the node from imported dataset on uuid collision
+* <info>replace</info> replace the node in the database on uuid collision
+* <info>throw</info> throw exception on uuid collision
+
 EOF
             );
     }
@@ -69,6 +78,7 @@ EOF
         $uuidBehavior = $input->getOption('uuid-behavior');
         if (!array_key_exists($uuidBehavior, self::UUID_BEHAVIOR)) {
             $output->writeln(sprintf('<error>UUID-Behavior "%s" is not supported</error>', $uuidBehavior));
+            $output->writeln(sprintf('Supported behaviors are %s', implode(', ', array_keys(self::UUID_BEHAVIOR))));
 
             return 1;
         }

--- a/tests/PHPCR/Tests/Util/Console/Command/WorkspaceImportCommandTest.php
+++ b/tests/PHPCR/Tests/Util/Console/Command/WorkspaceImportCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPCR\Tests\Util\Console\Command;
 
+use PHPCR\ImportUUIDBehaviorInterface;
 use PHPCR\RepositoryInterface;
 use PHPCR\Util\Console\Command\WorkspaceImportCommand;
 
@@ -14,7 +15,7 @@ class WorkspaceImportCommandTest extends BaseCommandTest
         $this->application->add(new WorkspaceImportCommand());
     }
 
-    public function testNodeTypeList()
+    public function testImport()
     {
         $this->session->expects($this->once())
             ->method('getRepository')
@@ -26,10 +27,34 @@ class WorkspaceImportCommandTest extends BaseCommandTest
             ->will($this->returnValue(true));
 
         $this->session->expects($this->once())
-            ->method('importXml');
+            ->method('importXml')
+            ->with('/', 'test_import.xml', ImportUUIDBehaviorInterface::IMPORT_UUID_CREATE_NEW);
 
         $ct = $this->executeCommand('phpcr:workspace:import', [
             'filename' => 'test_import.xml',
+        ]);
+
+        $this->assertContains('Successfully imported', $ct->getDisplay());
+    }
+
+    public function testImportUuidBehaviorThrow()
+    {
+        $this->session->expects($this->once())
+            ->method('getRepository')
+            ->will($this->returnValue($this->repository));
+
+        $this->repository->expects($this->once())
+            ->method('getDescriptor')
+            ->with(RepositoryInterface::OPTION_XML_IMPORT_SUPPORTED)
+            ->will($this->returnValue(true));
+
+        $this->session->expects($this->once())
+            ->method('importXml')
+            ->with('/', 'test_import.xml', ImportUUIDBehaviorInterface::IMPORT_UUID_COLLISION_THROW);
+
+        $ct = $this->executeCommand('phpcr:workspace:import', [
+            'filename'        => 'test_import.xml',
+            '--uuid-behavior' => 'throw',
         ]);
 
         $this->assertContains('Successfully imported', $ct->getDisplay());


### PR DESCRIPTION
This PR adds an option to control the uuid-behavior on import. To avoid a BC-break the default is set to `IMPORT_UUID_CREATE_NEW`.