### PR TITLE
Fix: Sql2Scanner Delimiter Regex

### DIFF
--- a/src/PHPCR/Util/QOM/Sql2Scanner.php
+++ b/src/PHPCR/Util/QOM/Sql2Scanner.php
@@ -171,7 +171,7 @@ class Sql2Scanner
             $regexpTokens[] = preg_quote($token, '/');
         }
 
-        $regexp = '/^'.implode('([ \t\n]+)', $regexpTokens).'$/';
+        $regexp = '/^'.implode('([ \t\n]*)', $regexpTokens).'$/';
         preg_match($regexp, $sql2, $this->delimiters);
         $this->delimiters[0] = '';
 

--- a/tests/PHPCR/Tests/Util/QOM/Sql2ScannerTest.php
+++ b/tests/PHPCR/Tests/Util/QOM/Sql2ScannerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace PHPCR\Tests\Util\QOM;
+
+use PHPCR\Util\QOM\Sql2Scanner;
+use PHPUnit\Framework\TestCase;
+
+class Sql2ScannerTest extends TestCase
+{
+    public function testToken()
+    {
+        $scanner = new Sql2Scanner('SELECT page.* FROM [nt:unstructured] AS page');
+        $expected = [
+            'SELECT',
+            'page',
+            '.',
+            '*',
+            'FROM',
+            '[nt:unstructured]',
+            'AS',
+            'page',
+        ];
+
+       while($token = $scanner->fetchNextToken()) {
+           $this->assertEquals(array_shift($expected), $token);
+       }
+    }
+
+    public function testDelimiter()
+    {
+        $scanner = new Sql2Scanner('SELECT page.* FROM [nt:unstructured] AS page');
+        $expected = [
+            '',
+            ' ',
+            '',
+            '',
+            ' ',
+            ' ',
+            ' ',
+            ' ',
+        ];
+
+        while($token = $scanner->fetchNextToken()) {
+            $this->assertEquals(array_shift($expected), $scanner->getPreviousDelimiter());
+        }
+    }
+}

--- a/tests/PHPCR/Tests/Util/QOM/Sql2ScannerTest.php
+++ b/tests/PHPCR/Tests/Util/QOM/Sql2ScannerTest.php
@@ -21,7 +21,7 @@ class Sql2ScannerTest extends TestCase
             'page',
         ];
 
-        while($token = $scanner->fetchNextToken()) {
+        while ($token = $scanner->fetchNextToken()) {
             $this->assertEquals(array_shift($expected), $token);
         }
     }
@@ -40,7 +40,7 @@ class Sql2ScannerTest extends TestCase
             ' ',
         ];
 
-        while($token = $scanner->fetchNextToken()) {
+        while ($token = $scanner->fetchNextToken()) {
             $this->assertEquals(array_shift($expected), $scanner->getPreviousDelimiter());
         }
     }

--- a/tests/PHPCR/Tests/Util/QOM/Sql2ScannerTest.php
+++ b/tests/PHPCR/Tests/Util/QOM/Sql2ScannerTest.php
@@ -21,9 +21,9 @@ class Sql2ScannerTest extends TestCase
             'page',
         ];
 
-       while($token = $scanner->fetchNextToken()) {
-           $this->assertEquals(array_shift($expected), $token);
-       }
+        while($token = $scanner->fetchNextToken()) {
+            $this->assertEquals(array_shift($expected), $token);
+        }
     }
 
     public function testDelimiter()


### PR DESCRIPTION
Perhaps related to: https://github.com/phpcr/phpcr-utils/pull/104

The generated regular expression in the Sql2Scanner does not take into account that there may be no character between two tokens. In our case the fallback to " " then broke the whole query.

Old variant:
https://regex101.com/r/4EkOyI/1

Corrected variant:
https://regex101.com/r/v61vHK/1