### PR TITLE
Allow Symfony 6

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -22,6 +22,8 @@ jobs:
                       dependencies: 'lowest'
                     - php-version: '7.4'
                     - php-version: '8.0'
+                    - php-version: '8.0'
+                      dev-dependencies: true
 
         steps:
             - name: Checkout project
@@ -32,6 +34,10 @@ jobs:
               with:
                   php-version: ${{ matrix.php-version }}
                   tools: 'composer:v2'
+
+            - name: Allow unstable dependencies
+              if: matrix.dev-dependencies == true
+              run: composer config minimum-stability dev
 
             - name: Install dependencies with Composer
               uses: ramsey/composer-install@v1

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": "^7.1 || ^8.0",
         "phpcr/phpcr": "~2.1.0",
-        "symfony/console": "^2.3 || ^3.0 || ^4.0 || ^5.0"
+        "symfony/console": "^2.3 || ^3.0 || ^4.0 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "ramsey/uuid": "^3.5",


### PR DESCRIPTION
There is no configured build that can execute with dev dependencies, do you want me to add one?

Needed for: https://github.com/doctrine/phpcr-odm/pull/821