### PR TITLE
Fixing the string tokenization

### DIFF
--- a/tests/PHPCR/Tests/Util/QOM/Sql2ScannerTest.php
+++ b/tests/PHPCR/Tests/Util/QOM/Sql2ScannerTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPCR\Tests\Util\QOM;
 
+use PHPCR\Query\InvalidQueryException;
 use PHPCR\Util\QOM\Sql2Scanner;
 use PHPUnit\Framework\TestCase;
 
@@ -24,24 +25,63 @@ class Sql2ScannerTest extends TestCase
         while ($token = $scanner->fetchNextToken()) {
             $this->assertEquals(array_shift($expected), $token);
         }
+        $this->assertCount(0, $expected);
     }
 
-    public function testDelimiter()
+    public function testStringTokenization()
     {
-        $scanner = new Sql2Scanner('SELECT page.* FROM [nt:unstructured] AS page');
+        $scanner = new Sql2Scanner('SELECT page.* FROM [nt:unstructured] AS page WHERE name ="Hello world"');
         $expected = [
-            '',
-            ' ',
-            '',
-            '',
-            ' ',
-            ' ',
-            ' ',
-            ' ',
+            'SELECT',
+            'page',
+            '.',
+            '*',
+            'FROM',
+            '[nt:unstructured]',
+            'AS',
+            'page',
+            'WHERE',
+            'name',
+            '=',
+            '"Hello world"',
         ];
 
         while ($token = $scanner->fetchNextToken()) {
-            $this->assertEquals(array_shift($expected), $scanner->getPreviousDelimiter());
+            $this->assertEquals(array_shift($expected), $token);
         }
+        $this->assertCount(0, $expected);
+    }
+
+    public function testStringTokenizationWithNewLines()
+    {
+        $scanner = new Sql2Scanner(<<<'SQL'
+SELECT page.* 
+FROM [nt:unstructured] AS page WHERE name ="Hello world"
+SQL);
+        $expected = [
+            'SELECT',
+            'page',
+            '.',
+            '*',
+            'FROM',
+            '[nt:unstructured]',
+            'AS',
+            'page',
+            'WHERE',
+            'name',
+            '=',
+            '"Hello world"',
+        ];
+
+        while ($token = $scanner->fetchNextToken()) {
+            $this->assertEquals(array_shift($expected), $token);
+        }
+        $this->assertCount(0, $expected);
+    }
+
+    public function testThrowingErrorOnUnclosedString()
+    {
+        $this->expectException(InvalidQueryException::class);
+        new Sql2Scanner('SELECT page.* FROM [nt:unstructured] AS page WHERE name ="Hello ');
     }
 }

--- a/tests/PHPCR/Tests/Util/QOM/Sql2ScannerTest.php
+++ b/tests/PHPCR/Tests/Util/QOM/Sql2ScannerTest.php
@@ -57,7 +57,7 @@ class Sql2ScannerTest extends TestCase
 
     public function dataTestStringTokenization()
     {
-        $multilineQuery = <<<'SQL'
+        $multilineQuery = <<<SQL
 SELECT page.* 
 FROM [nt:unstructured] AS page 
 WHERE name ="Hello world"
@@ -71,9 +71,10 @@ SQL;
 
     public function testEscapingStrings()
     {
-        $scanner = new Sql2Scanner(<<<SQL
+        $sql = <<<SQL
 SELECT page.* FROM [nt:unstructured] AS page WHERE page.quotes = "\"'"
-SQL);
+SQL;
+        $scanner = new Sql2Scanner($sql);
         $expected = [
             'SELECT',
             'page',


### PR DESCRIPTION
In the current version of the scanner, the scanner splits the string by spaces and then in a second pass it just gets the spaces in order to put the strings back together in the QueryConverter. This doesn't make much sense and can be very harmful to bigger queries. (as we found out even `preg_match` has a size limitation). 

After this merge request it parses the strings in the query directly into one token which also simplifies the QueryConverter. 