### PR TITLE
Update getQuery QueryObjectModelInterface method

### DIFF
--- a/src/PHPCR/Util/QOM/QueryBuilder.php
+++ b/src/PHPCR/Util/QOM/QueryBuilder.php
@@ -399,6 +399,8 @@ class QueryBuilder
 
     /**
      * Gets the query built.
+     *
+     * @return QueryObjectModelInterface
      */
     public function getQuery(): ?QueryObjectModelInterface
     {

--- a/src/PHPCR/Util/QOM/QueryBuilder.php
+++ b/src/PHPCR/Util/QOM/QueryBuilder.php
@@ -399,10 +399,8 @@ class QueryBuilder
 
     /**
      * Gets the query built.
-     *
-     * @return QueryObjectModelInterface
      */
-    public function getQuery(): ?QueryObjectModelInterface
+    public function getQuery(): QueryObjectModelInterface
     {
         if (null !== $this->query && self::STATE_CLEAN === $this->state) {
             return $this->query;


### PR DESCRIPTION
I think there is not any case where `getQuery` can be null in this method.